### PR TITLE
Add public verify.qrv.network frontend and /[qrvid] verification route

### DIFF
--- a/app/[qrvid]/loading.tsx
+++ b/app/[qrvid]/loading.tsx
@@ -1,0 +1,18 @@
+export default function Loading() {
+  return (
+    <main className="page-wrap">
+      <section className="verify-card" aria-busy="true" aria-live="polite">
+        <div className="skeleton skeleton-badge" />
+        <div className="skeleton skeleton-message" />
+        <div className="fields-grid">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <article className="data-field" key={index}>
+              <div className="skeleton skeleton-label" />
+              <div className="skeleton skeleton-value" />
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/[qrvid]/page.tsx
+++ b/app/[qrvid]/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { VerifyView } from '@/components/verify/VerifyView';
+import { fetchVerification } from '@/lib/verification';
+
+type Params = { qrvid: string };
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { qrvid } = await params;
+
+  return {
+    title: `Verification ${qrvid}`,
+    description: `Verification details for QRVID ${qrvid} from QRV registry.`,
+    alternates: {
+      canonical: `/${encodeURIComponent(qrvid)}`,
+    },
+  };
+}
+
+export default async function VerifyRoute({ params }: { params: Promise<Params> }) {
+  const { qrvid } = await params;
+
+  if (!qrvid?.trim()) {
+    notFound();
+  }
+
+  const record = await fetchVerification(qrvid);
+  return <VerifyView record={record} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,203 @@
-*{box-sizing:border-box}body{margin:0;font-family:Inter,Arial,sans-serif;background:#f4f6fb;color:#111827}a{color:inherit;text-decoration:none}
-.shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}.sidebar{background:#0f172a;color:#e2e8f0;padding:16px}.main{display:flex;flex-direction:column}.topbar{background:#fff;border-bottom:1px solid #e5e7eb;padding:12px 16px;display:flex;justify-content:space-between;align-items:center;gap:12px;position:sticky;top:0}
-.content{padding:16px;display:grid;gap:16px}.card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:16px}.btn{border:0;border-radius:8px;padding:8px 12px;cursor:pointer;background:#2563eb;color:#fff}.btn.secondary{background:#e5e7eb;color:#111}.btn.danger{background:#dc2626}.grid{display:grid;gap:12px}.grid.cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.mono{font-family:ui-monospace,SFMono-Regular,monospace}.badge{padding:2px 8px;border-radius:99px;font-size:12px;font-weight:600}
-.table{width:100%;border-collapse:collapse}.table th,.table td{padding:10px;border-bottom:1px solid #e5e7eb;text-align:left}.input,.select,textarea{width:100%;padding:8px;border:1px solid #d1d5db;border-radius:8px}
-@media (max-width:980px){.shell{grid-template-columns:1fr}.sidebar{display:none}.grid.cols-3{grid-template-columns:1fr}}
+:root {
+  --navy-950: #07142d;
+  --navy-900: #0b1f46;
+  --navy-700: #1c3f82;
+  --white: #ffffff;
+  --gold-500: #d4a63a;
+  --gold-300: #f3d68c;
+  --ink-700: #31405d;
+  --ink-500: #566789;
+  --surface: #f3f6fd;
+  --line: #d8e0ef;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, #16366f 0%, var(--navy-950) 56%);
+  min-height: 100vh;
+  color: var(--white);
+}
+
+.page-wrap {
+  min-height: 100vh;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.verify-card {
+  width: min(100%, 52rem);
+  border-radius: 1rem;
+  border: 1px solid #274781;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.01));
+  backdrop-filter: blur(6px);
+  box-shadow: 0 16px 32px rgba(1, 12, 31, 0.35);
+  padding: 1rem;
+}
+
+.hero-card h1 {
+  font-size: clamp(1.35rem, 6vw, 2.1rem);
+  margin: 0.2rem 0 0.65rem;
+}
+
+.hero-copy {
+  color: #d7e2f8;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.primary-link {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--navy-950);
+  background: linear-gradient(135deg, var(--gold-300), var(--gold-500));
+  border-radius: 999px;
+  font-weight: 700;
+  padding: 0.68rem 1rem;
+}
+
+.verify-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.eyebrow {
+  margin: 0;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--gold-300);
+}
+
+.status-badge {
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+
+.status-verified {
+  background: rgba(15, 157, 88, 0.2);
+  color: #87f8bd;
+  border: 1px solid rgba(135, 248, 189, 0.35);
+}
+
+.status-revoked,
+.status-expired,
+.status-error {
+  background: rgba(253, 78, 78, 0.16);
+  color: #ffc4c4;
+  border: 1px solid rgba(255, 174, 174, 0.3);
+}
+
+.status-not-found {
+  background: rgba(255, 205, 102, 0.18);
+  color: #ffe4a5;
+  border: 1px solid rgba(255, 221, 148, 0.32);
+}
+
+.status-message {
+  margin: 0.75rem 0 1.15rem;
+  color: #d9e5fc;
+}
+
+.fields-grid {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.data-field {
+  border: 1px solid rgba(215, 227, 251, 0.2);
+  border-radius: 0.8rem;
+  padding: 0.75rem;
+  background: rgba(1, 10, 24, 0.28);
+}
+
+.field-label {
+  margin: 0;
+  color: #aabde2;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.field-value {
+  margin: 0.4rem 0 0;
+  color: var(--white);
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9rem;
+}
+
+.skeleton {
+  border-radius: 0.5rem;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.08));
+  background-size: 200% 100%;
+  animation: shimmer 1.2s infinite;
+}
+
+.skeleton-badge {
+  width: 8rem;
+  height: 1.8rem;
+}
+
+.skeleton-message {
+  margin-top: 0.7rem;
+  width: 70%;
+  height: 1rem;
+}
+
+.skeleton-label {
+  width: 35%;
+  height: 0.8rem;
+}
+
+.skeleton-value {
+  width: 75%;
+  height: 1.1rem;
+  margin-top: 0.55rem;
+}
+
+@keyframes shimmer {
+  from {
+    background-position: 200% 0;
+  }
+
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .page-wrap {
+    padding: 2rem;
+  }
+
+  .verify-card {
+    padding: 1.5rem;
+  }
+
+  .verify-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .fields-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,38 @@
+import type { Metadata } from 'next';
 import './globals.css';
-import { AuthBoundary } from '@/components/auth/AuthBoundary';
-import { AppShell } from '@/components/layout/AppShell';
 
-export const dynamic = 'force-dynamic';
-export const metadata = { title: 'QR-V Issuer Portal' };
+export const metadata: Metadata = {
+  metadataBase: new URL('https://verify.qrv.network'),
+  title: {
+    default: 'QRV Verify | Trusted Credential Verification',
+    template: '%s | QRV Verify',
+  },
+  description:
+    'Verify QRV credentials instantly with tamper-evident registry checks. Trusted verification for issuers, owners, and relying parties.',
+  applicationName: 'QRV Verify',
+  keywords: ['QRV', 'credential verification', 'digital certificate', 'registry verification'],
+  openGraph: {
+    title: 'QRV Verify',
+    description: 'Public verification portal for QRV credential records.',
+    url: 'https://verify.qrv.network',
+    siteName: 'QRV Verify',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'QRV Verify',
+    description: 'Check credential integrity and status in seconds.',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return <html lang="en"><body><AuthBoundary><AppShell>{children}</AppShell></AuthBoundary></body></html>;
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,11 +1,30 @@
 'use client';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { Button, Card, Input } from '@/components/shared/ui';
 
-export default function LoginPage(){
+export default function LoginPage() {
   const router = useRouter();
-  const params = useSearchParams();
-  const next = params.get('next') || '/dashboard';
 
-  return <Card><h1>Issuer Login</h1><p>Authentication placeholder. Production requires real SSO/session integration.</p><label>Email<Input aria-label='email' /></label><label>Password<Input aria-label='password' type='password' /></label><Button onClick={()=>{document.cookie='qrv_issuer_session=1; path=/; max-age=28800; samesite=lax'; router.push(next);}}>Sign in</Button></Card>;
+  function handleSignIn() {
+    const params = new URLSearchParams(window.location.search);
+    const next = params.get('next') || '/dashboard';
+    document.cookie = 'qrv_issuer_session=1; path=/; max-age=28800; samesite=lax';
+    router.push(next);
+  }
+
+  return (
+    <Card>
+      <h1>Issuer Login</h1>
+      <p>Authentication placeholder. Production requires real SSO/session integration.</p>
+      <label>
+        Email
+        <Input aria-label="email" />
+      </label>
+      <label>
+        Password
+        <Input aria-label="password" type="password" />
+      </label>
+      <Button onClick={handleSignIn}>Sign in</Button>
+    </Card>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,2 +1,19 @@
-import { redirect } from 'next/navigation';
-export default function Home(){redirect('/dashboard');}
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="page-wrap">
+      <section className="verify-card hero-card">
+        <p className="eyebrow">QRV Public Verification</p>
+        <h1>Trust every credential before you rely on it.</h1>
+        <p className="hero-copy">
+          Open a verification URL in the format <span className="mono">/your-qrvid</span> to view
+          issuer, ownership, hash, and status details directly from the QRV registry.
+        </p>
+        <Link href="/sample-qrvid" className="primary-link" prefetch={false}>
+          Try sample route
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/components/verify/VerifyView.tsx
+++ b/components/verify/VerifyView.tsx
@@ -1,0 +1,68 @@
+import type { VerificationRecord, VerifyStatus } from '@/lib/verification';
+import { formatDate } from '@/lib/verification';
+
+const STATUS_LABELS: Record<VerifyStatus, { text: string; className: string; message: string }> = {
+  VERIFIED: {
+    text: 'VERIFIED',
+    className: 'status-verified',
+    message: 'This credential is valid and active in the registry.',
+  },
+  REVOKED: {
+    text: 'REVOKED',
+    className: 'status-revoked',
+    message: 'This credential was revoked and should not be accepted.',
+  },
+  EXPIRED: {
+    text: 'EXPIRED',
+    className: 'status-expired',
+    message: 'This credential has expired and is no longer valid.',
+  },
+  NOT_FOUND: {
+    text: 'NOT FOUND',
+    className: 'status-not-found',
+    message: 'No matching registry record was found for this QRVID.',
+  },
+  ERROR: {
+    text: 'ERROR',
+    className: 'status-error',
+    message: 'We could not reach the registry. Please retry in a moment.',
+  },
+};
+
+type Props = {
+  record: VerificationRecord;
+};
+
+function Field({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <article className="data-field">
+      <p className="field-label">{label}</p>
+      <p className={mono ? 'field-value mono' : 'field-value'}>{value}</p>
+    </article>
+  );
+}
+
+export function VerifyView({ record }: Props) {
+  const status = STATUS_LABELS[record.status];
+
+  return (
+    <main className="page-wrap">
+      <section className="verify-card">
+        <header className="verify-header">
+          <p className="eyebrow">QRV Registry Verification</p>
+          <span className={`status-badge ${status.className}`}>{status.text}</span>
+        </header>
+        <p className="status-message">{status.message}</p>
+
+        <section className="fields-grid" aria-label="verification details">
+          <Field label="Issuer" value={record.issuer} />
+          <Field label="Record Type" value={record.recordType} />
+          <Field label="Owner" value={record.owner} />
+          <Field label="Created Date" value={formatDate(record.createdDate)} />
+          <Field label="Hash" value={record.hash} mono />
+          <Field label="QRVID" value={record.qrvid} mono />
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/lib/verification.ts
+++ b/lib/verification.ts
@@ -1,0 +1,100 @@
+export type VerifyStatus = 'VERIFIED' | 'REVOKED' | 'EXPIRED' | 'NOT_FOUND' | 'ERROR';
+
+export type VerificationRecord = {
+  status: VerifyStatus;
+  issuer: string;
+  recordType: string;
+  owner: string;
+  createdDate: string;
+  hash: string;
+  qrvid: string;
+};
+
+const REGISTRY_BASE_URL = 'https://registry.qrv.network/verify';
+
+function asText(value: unknown, fallback = 'Unavailable') {
+  return typeof value === 'string' && value.trim() ? value : fallback;
+}
+
+export async function fetchVerification(qrvid: string): Promise<VerificationRecord> {
+  const encodedQrvid = encodeURIComponent(qrvid.trim());
+
+  try {
+    const response = await fetch(`${REGISTRY_BASE_URL}/${encodedQrvid}`, {
+      method: 'GET',
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (response.status === 404) {
+      return {
+        status: 'NOT_FOUND',
+        issuer: 'Unavailable',
+        recordType: 'Unavailable',
+        owner: 'Unavailable',
+        createdDate: 'Unavailable',
+        hash: 'Unavailable',
+        qrvid,
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        status: 'ERROR',
+        issuer: 'Unavailable',
+        recordType: 'Unavailable',
+        owner: 'Unavailable',
+        createdDate: 'Unavailable',
+        hash: 'Unavailable',
+        qrvid,
+      };
+    }
+
+    const data: Record<string, unknown> = await response.json();
+    const rawStatus = asText(data.status, 'ERROR').toUpperCase();
+    const status: VerifyStatus =
+      rawStatus === 'VERIFIED' || rawStatus === 'REVOKED' || rawStatus === 'EXPIRED'
+        ? rawStatus
+        : 'ERROR';
+
+    return {
+      status,
+      issuer: asText(data.issuer),
+      recordType: asText(data.recordType ?? data.record_type),
+      owner: asText(data.owner),
+      createdDate: asText(data.createdDate ?? data.created_at),
+      hash: asText(data.hash),
+      qrvid: asText(data.qrvid, qrvid),
+    };
+  } catch {
+    return {
+      status: 'ERROR',
+      issuer: 'Unavailable',
+      recordType: 'Unavailable',
+      owner: 'Unavailable',
+      createdDate: 'Unavailable',
+      hash: 'Unavailable',
+      qrvid,
+    };
+  }
+}
+
+export function formatDate(rawDate: string): string {
+  const parsed = new Date(rawDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return rawDate;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  }).format(parsed);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,21 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  output: 'standalone',
+  poweredByHeader: false,
+  reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
+    ];
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
### Motivation
- Provide a public, production-ready verification endpoint for QRV records so anyone can validate credentials at `verify.qrv.network/[qrvid]`.
- Surface clear, trust-focused status information (VERIFIED / REVOKED / EXPIRED / NOT_FOUND / ERROR) alongside issuer and record details for relying parties.
- Ship a mobile-first, deployable frontend with SEO metadata and defensive defaults for reliable hosting on Vercel/Hostinger.

### Description
- Added a registry client `lib/verification.ts` that fetches `https://registry.qrv.network/verify/:qrvid`, normalizes fields, and maps statuses to `VERIFIED | REVOKED | EXPIRED | NOT_FOUND | ERROR`.
- Implemented server route `app/[qrvid]/page.tsx` with per-route metadata and `app/[qrvid]/loading.tsx` for a skeleton loading state, and created `components/verify/VerifyView.tsx` to render the status badge and required fields (Issuer, Record Type, Owner, Created Date, Hash, QRVID).
- Replaced the previous app layout with public-facing metadata in `app/layout.tsx` and added a friendly root landing page at `/` in `app/page.tsx` explaining the verification route.
- Introduced a navy/white/gold mobile-first design and skeleton shimmer in `app/globals.css` to match the trust-focused brand style.
- Made Next.js production settings and basic security headers in `next.config.ts` (`output: 'standalone'`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`).
- Adjusted `app/login/page.tsx` to avoid `useSearchParams` server prerender bailout by reading `window.location.search` inside the client action, ensuring successful production builds.

### Testing
- Ran `npm install --include=dev` and the install completed successfully.
- Ran `npm run typecheck` and TypeScript checks passed.
- Ran `npm run build` and the Next.js production build completed successfully (static & dynamic routes generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9a651260832dbac67e62873d7336)