### PR TITLE
Fix issuer/verify domain role separation on homepage

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,33 +1,67 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import { getAppRole } from '@/lib/app-role';
 
-export const metadata: Metadata = {
-  metadataBase: new URL('https://verify.qrv.network'),
-  title: {
-    default: 'QRV Verify | Trusted Credential Verification',
-    template: '%s | QRV Verify',
+const appRole = getAppRole();
+
+const metadataByRole: Record<string, Metadata> = {
+  issuer: {
+    metadataBase: new URL('https://issuer.qrv.network'),
+    title: {
+      default: 'QRV Issuer Portal | Credential Operations',
+      template: '%s | QRV Issuer Portal',
+    },
+    description:
+      'Manage credential issuance, revocations, analytics, API keys, and issuer settings from the QRV control plane.',
+    applicationName: 'QRV Issuer Portal',
+    keywords: ['QRV', 'issuer portal', 'credential issuance', 'revocation management'],
+    openGraph: {
+      title: 'QRV Issuer Portal',
+      description: 'Issuer control plane for managing verifiable credentials.',
+      url: 'https://issuer.qrv.network',
+      siteName: 'QRV Issuer Portal',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: 'QRV Issuer Portal',
+      description: 'Issue and manage credentials with full lifecycle controls.',
+    },
+    robots: {
+      index: false,
+      follow: false,
+    },
   },
-  description:
-    'Verify QRV credentials instantly with tamper-evident registry checks. Trusted verification for issuers, owners, and relying parties.',
-  applicationName: 'QRV Verify',
-  keywords: ['QRV', 'credential verification', 'digital certificate', 'registry verification'],
-  openGraph: {
-    title: 'QRV Verify',
-    description: 'Public verification portal for QRV credential records.',
-    url: 'https://verify.qrv.network',
-    siteName: 'QRV Verify',
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'QRV Verify',
-    description: 'Check credential integrity and status in seconds.',
-  },
-  robots: {
-    index: true,
-    follow: true,
+  verify: {
+    metadataBase: new URL('https://verify.qrv.network'),
+    title: {
+      default: 'QRV Verify | Trusted Credential Verification',
+      template: '%s | QRV Verify',
+    },
+    description:
+      'Verify QRV credentials instantly with tamper-evident registry checks. Trusted verification for issuers, owners, and relying parties.',
+    applicationName: 'QRV Verify',
+    keywords: ['QRV', 'credential verification', 'digital certificate', 'registry verification'],
+    openGraph: {
+      title: 'QRV Verify',
+      description: 'Public verification portal for QRV credential records.',
+      url: 'https://verify.qrv.network',
+      siteName: 'QRV Verify',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: 'QRV Verify',
+      description: 'Check credential integrity and status in seconds.',
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
   },
 };
+
+export const metadata: Metadata = metadataByRole[appRole] || metadataByRole.issuer;
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,14 @@
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getAppRole } from '@/lib/app-role';
 
 export default function HomePage() {
+  const appRole = getAppRole();
+
+  if (appRole === 'issuer') {
+    redirect('/login');
+  }
+
   return (
     <main className="page-wrap">
       <section className="verify-card hero-card">

--- a/lib/app-role.ts
+++ b/lib/app-role.ts
@@ -1,0 +1,11 @@
+export type AppRole = 'issuer' | 'verify';
+
+const ROLE_MAP: Record<string, AppRole> = {
+  issuer: 'issuer',
+  verify: 'verify',
+};
+
+export function getAppRole(): AppRole {
+  const role = process.env.NEXT_PUBLIC_APP_ROLE?.toLowerCase() || 'issuer';
+  return ROLE_MAP[role] || 'issuer';
+}

--- a/tests/app-role.test.ts
+++ b/tests/app-role.test.ts
@@ -1,0 +1,23 @@
+describe('getAppRole', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it('defaults to issuer when env is unset', async () => {
+    const { getAppRole } = await import('@/lib/app-role');
+    expect(getAppRole()).toBe('issuer');
+  });
+
+  it('returns verify role when env is verify', async () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_ROLE', 'verify');
+    const { getAppRole } = await import('@/lib/app-role');
+    expect(getAppRole()).toBe('verify');
+  });
+
+  it('falls back to issuer for unsupported values', async () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_ROLE', 'api');
+    const { getAppRole } = await import('@/lib/app-role');
+    expect(getAppRole()).toBe('issuer');
+  });
+});

--- a/tests/home-page-role.test.tsx
+++ b/tests/home-page-role.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+const redirectMock = vi.fn(() => {
+  throw new Error('NEXT_REDIRECT');
+});
+
+vi.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => redirectMock(...args),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('home page role routing', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    redirectMock.mockClear();
+  });
+
+  it('redirects issuer role home route to /login', async () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_ROLE', 'issuer');
+    const { default: HomePage } = await import('@/app/page');
+
+    expect(() => HomePage()).toThrow('NEXT_REDIRECT');
+    expect(redirectMock).toHaveBeenCalledWith('/login');
+  });
+
+  it('renders verification landing for verify role', async () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_ROLE', 'verify');
+    const { default: HomePage } = await import('@/app/page');
+
+    render(HomePage());
+
+    expect(screen.getByText('QRV Public Verification')).toBeInTheDocument();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- The issuer domain was serving the public verification landing at `/`, causing issuer.qrv.network to show the wrong UI instead of the issuer control plane.
- The change enforces domain role ownership so an issuer deployment opens the issuer auth flow while verify deployments remain public-facing.

### Description
- Added `lib/app-role.ts` and introduced `NEXT_PUBLIC_APP_ROLE` role resolution with a safe fallback to `issuer`.
- Updated `app/page.tsx` to consult the role and `redirect('/login')` when the role is `issuer`, while preserving the verify landing for the `verify` role.
- Made root metadata role-aware in `app/layout.tsx` so branding, `metadataBase`, and robots settings align to `issuer` vs `verify` deployments.
- Added unit tests `tests/app-role.test.ts` and `tests/home-page-role.test.tsx`, and retained the issuer login page at `app/login/page.tsx`.

### Testing
- Ran role and route unit tests with `npm test -- --run tests/app-role.test.ts tests/home-page-role.test.tsx tests/routes.smoke.test.tsx` and all tests passed (20/20).
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed13740260832d91ace04f4cd5ce35)