### PR TITLE
Add app-role routing for verify domain and verify-domain smoke checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,16 @@ npm run dev
 npm run check
 npm test
 ```
+
+## App role routing
+
+This Next.js app supports two deployment roles via `NEXT_PUBLIC_APP_ROLE`:
+
+- `issuer` → `/` redirects to `/login` and issuer portal routes are available.
+- `verify` → `/` renders the public verification landing page and `/{qrvid}` renders public verification results.
+
+Verification records are fetched from:
+
+- `${NEXT_PUBLIC_QRV_API_BASE_URL}/api/v1/verify/{qrvid}`
+
+See `docs/verify-domain-deployment.md` for host/domain rollout steps.

--- a/app/[qrvid]/page.tsx
+++ b/app/[qrvid]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { VerifyView } from '@/components/verify/VerifyView';
+import { isIssuerRole } from '@/lib/app-role';
 import { fetchVerification } from '@/lib/verification';
 
 type Params = { qrvid: string };
@@ -18,6 +19,10 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
 }
 
 export default async function VerifyRoute({ params }: { params: Promise<Params> }) {
+  if (isIssuerRole()) {
+    notFound();
+  }
+
   const { qrvid } = await params;
 
   if (!qrvid?.trim()) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,12 @@
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { isIssuerRole } from '@/lib/app-role';
 
 export default function HomePage() {
+  if (isIssuerRole()) {
+    redirect('/login');
+  }
+
   return (
     <main className="page-wrap">
       <section className="verify-card hero-card">
@@ -10,7 +16,7 @@ export default function HomePage() {
           Open a verification URL in the format <span className="mono">/your-qrvid</span> to view
           issuer, ownership, hash, and status details directly from the QRV registry.
         </p>
-        <Link href="/sample-qrvid" className="primary-link" prefetch={false}>
+        <Link href="/QRV-PROD-CERT-000001" className="primary-link" prefetch={false}>
           Try sample route
         </Link>
       </section>

--- a/docs/verify-domain-deployment.md
+++ b/docs/verify-domain-deployment.md
@@ -1,0 +1,64 @@
+# verify.qrv.network deployment guide
+
+This guide configures the same `issuer-qrv` Next.js app to run as the **public verify frontend** on `verify.qrv.network`.
+
+## 1) Hostinger settings
+
+In Hostinger (or your Node host), configure `verify.qrv.network` to deploy this repo and run the Next.js app:
+
+- Build command: `npm run build`
+- Start command: `npm run start`
+- Node runtime: 20+
+- Do **not** point verify traffic at the legacy Express fallback server (`npm run start:server`), because that process responds with plain text and does not serve the Next frontend routes.
+
+## 2) Required environment variables
+
+Set these for the **verify** deployment:
+
+```bash
+NEXT_PUBLIC_APP_ROLE=verify
+NEXT_PUBLIC_QRV_API_BASE_URL=https://api.qrv.network
+```
+
+Set these for the **issuer** deployment:
+
+```bash
+NEXT_PUBLIC_APP_ROLE=issuer
+NEXT_PUBLIC_QRV_API_BASE_URL=https://api.qrv.network
+```
+
+Notes:
+
+- The verify UI resolves records through `GET ${NEXT_PUBLIC_QRV_API_BASE_URL}/api/v1/verify/{qrvid}`.
+- If `NEXT_PUBLIC_APP_ROLE` is missing/invalid, the app defaults to `issuer` behavior.
+
+## 3) Expected routes by role
+
+### verify role (`NEXT_PUBLIC_APP_ROLE=verify`)
+
+- `/` renders **QRV Public Verification** landing page.
+- `/QRV-PROD-CERT-000001` renders verification details from API.
+- `/{unknown-qrvid}` renders NOT_FOUND state in verification UI.
+
+### issuer role (`NEXT_PUBLIC_APP_ROLE=issuer`)
+
+- `/` redirects to `/login`.
+- `/{qrvid}` public verify page is not served.
+
+## 4) Smoke tests
+
+Run post-deploy smoke checks:
+
+```bash
+VERIFY_BASE_URL=https://verify.qrv.network \
+SEEDED_QRVID=QRV-PROD-CERT-000001 \
+npm run smoke:verify-domain
+```
+
+The smoke script validates:
+
+1. verify root (`/`) returns HTML and includes `QRV Public Verification`.
+2. seeded QRVID page returns HTML and includes `VERIFIED` UI text.
+3. unknown QRVID page returns HTML and includes `NOT_FOUND` UI text.
+
+If any check returns plain `Not found` text or a non-HTML response, the deployment is still misrouted.

--- a/lib/app-role.ts
+++ b/lib/app-role.ts
@@ -1,0 +1,18 @@
+export type AppRole = 'issuer' | 'verify';
+
+function normalizeRole(rawRole: string | undefined): AppRole {
+  const normalized = rawRole?.trim().toLowerCase();
+  return normalized === 'verify' ? 'verify' : 'issuer';
+}
+
+export function getAppRole(): AppRole {
+  return normalizeRole(process.env.NEXT_PUBLIC_APP_ROLE);
+}
+
+export function isVerifyRole(): boolean {
+  return getAppRole() === 'verify';
+}
+
+export function isIssuerRole(): boolean {
+  return getAppRole() === 'issuer';
+}

--- a/lib/verification.ts
+++ b/lib/verification.ts
@@ -12,7 +12,7 @@ export type VerificationRecord = {
   qrvid: string;
 };
 
-const VERIFY_API_BASE_URL = process.env.NEXT_PUBLIC_QRV_VERIFY_API_BASE_URL ?? 'https://api.qrv.network/verify';
+const VERIFY_API_BASE_URL = process.env.NEXT_PUBLIC_QRV_API_BASE_URL ?? 'https://api.qrv.network';
 
 function asText(value: unknown, fallback = 'Unavailable') {
   return typeof value === 'string' && value.trim() ? value : fallback;
@@ -30,12 +30,25 @@ function deriveProofReference(data: Record<string, unknown>) {
   return asText(data.hash ?? data.proofReference ?? data.proof_reference, 'Unavailable');
 }
 
+function getUnavailableRecord(qrvid: string, verifiedAt: string): VerificationRecord {
+  return {
+    status: 'NOT_FOUND',
+    issuerName: 'Unavailable',
+    credentialTitle: 'Unavailable',
+    subjectDisplay: 'Unavailable',
+    issuedAt: 'Unavailable',
+    verifiedAt,
+    proofReference: 'Unavailable',
+    qrvid,
+  };
+}
+
 export async function fetchVerification(qrvid: string): Promise<VerificationRecord> {
   const encodedQrvid = encodeURIComponent(qrvid.trim());
   const verifiedAt = new Date().toISOString();
 
   try {
-    const response = await fetch(`${VERIFY_API_BASE_URL}/${encodedQrvid}`, {
+    const response = await fetch(`${VERIFY_API_BASE_URL}/api/v1/verify/${encodedQrvid}`, {
       method: 'GET',
       cache: 'no-store',
       headers: {
@@ -43,30 +56,8 @@ export async function fetchVerification(qrvid: string): Promise<VerificationReco
       },
     });
 
-    if (response.status === 404) {
-      return {
-        status: 'NOT_FOUND',
-        issuerName: 'Unavailable',
-        credentialTitle: 'Unavailable',
-        subjectDisplay: 'Unavailable',
-        issuedAt: 'Unavailable',
-        verifiedAt,
-        proofReference: 'Unavailable',
-        qrvid,
-      };
-    }
-
     if (!response.ok) {
-      return {
-        status: 'NOT_FOUND',
-        issuerName: 'Unavailable',
-        credentialTitle: 'Unavailable',
-        subjectDisplay: 'Unavailable',
-        issuedAt: 'Unavailable',
-        verifiedAt,
-        proofReference: 'Unavailable',
-        qrvid,
-      };
+      return getUnavailableRecord(qrvid, verifiedAt);
     }
 
     const data: Record<string, unknown> = await response.json();
@@ -88,16 +79,7 @@ export async function fetchVerification(qrvid: string): Promise<VerificationReco
       qrvid: asText(data.qrvid, qrvid),
     };
   } catch {
-    return {
-      status: 'NOT_FOUND',
-      issuerName: 'Unavailable',
-      credentialTitle: 'Unavailable',
-      subjectDisplay: 'Unavailable',
-      issuedAt: 'Unavailable',
-      verifiedAt,
-      proofReference: 'Unavailable',
-      qrvid,
-    };
+    return getUnavailableRecord(qrvid, verifiedAt);
   }
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getAppRole } from '@/lib/app-role';
 
-const PUBLIC_PATHS = ['/', '/login', '/healthz', '/readyz', '/version'];
+const ISSUER_PUBLIC_PATHS = ['/login', '/healthz', '/readyz', '/version'];
 
-function isPublicPath(pathname: string): boolean {
+function isNextInternalPath(pathname: string): boolean {
   return (
-    PUBLIC_PATHS.includes(pathname) ||
     pathname.startsWith('/_next') ||
     pathname.startsWith('/favicon') ||
     pathname.startsWith('/api') ||
@@ -12,10 +12,36 @@ function isPublicPath(pathname: string): boolean {
   );
 }
 
+function isVerifyRecordPath(pathname: string): boolean {
+  if (!pathname.startsWith('/')) {
+    return false;
+  }
+
+  const segments = pathname.split('/').filter(Boolean);
+  return segments.length === 1;
+}
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const appRole = getAppRole();
 
-  if (isPublicPath(pathname)) {
+  if (isNextInternalPath(pathname)) {
+    return NextResponse.next();
+  }
+
+  if (appRole === 'verify') {
+    if (pathname === '/' || pathname === '/healthz' || pathname === '/readyz' || pathname === '/version' || isVerifyRecordPath(pathname)) {
+      return NextResponse.next();
+    }
+
+    return NextResponse.redirect(new URL('/', request.url));
+  }
+
+  if (pathname === '/') {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  if (ISSUER_PUBLIC_PATHS.includes(pathname)) {
     return NextResponse.next();
   }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "smoke:e2e": "node scripts/e2e-smoke.mjs",
     "smoke:external": "node scripts/external-smoke.mjs",
     "check": "npm run lint && npm run typecheck && npm test",
-    "validate:prod": "node scripts/validate-prod.mjs"
+    "validate:prod": "node scripts/validate-prod.mjs",
+    "smoke:verify-domain": "node scripts/verify-domain-smoke.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/scripts/verify-domain-smoke.mjs
+++ b/scripts/verify-domain-smoke.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const VERIFY_BASE_URL = process.env.VERIFY_BASE_URL || 'https://verify.qrv.network';
+const SEEDED_QRVID = process.env.SEEDED_QRVID || 'QRV-PROD-CERT-000001';
+const UNKNOWN_QRVID = process.env.UNKNOWN_QRVID || `QRV-UNKNOWN-${Date.now()}`;
+
+async function expectHtml(pathname, requiredText) {
+  const url = `${VERIFY_BASE_URL}${pathname}`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'text/html',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed (${response.status})`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('text/html')) {
+    throw new Error(`GET ${url} returned non-HTML content-type '${contentType}'`);
+  }
+
+  const html = await response.text();
+  if (html.trim().toLowerCase() === 'not found') {
+    throw new Error(`GET ${url} returned plain text 'Not found' instead of HTML`);
+  }
+
+  if (!html.includes(requiredText)) {
+    throw new Error(`GET ${url} HTML did not include expected text '${requiredText}'`);
+  }
+
+  return { url, status: response.status, contentType };
+}
+
+async function run() {
+  const root = await expectHtml('/', 'QRV Public Verification');
+  const seeded = await expectHtml(`/${encodeURIComponent(SEEDED_QRVID)}`, 'VERIFIED');
+  const unknown = await expectHtml(`/${encodeURIComponent(UNKNOWN_QRVID)}`, 'NOT_FOUND');
+
+  console.log('Verify-domain smoke checks passed');
+  console.log(
+    JSON.stringify(
+      {
+        verifyBaseUrl: VERIFY_BASE_URL,
+        seededQrvid: SEEDED_QRVID,
+        unknownQrvid: UNKNOWN_QRVID,
+        checks: { root, seeded, unknown },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+run().catch((error) => {
+  console.error('Verify-domain smoke checks failed');
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Fix verify.qrv.network serving plain text "Not found" by enabling the Next.js public verification frontend to be served on the verify domain.  
- Support two deployment roles (`issuer` / `verify`) so the same repo can run the issuer portal or the public verify UI depending on env.  
- Ensure public verification pages fetch from the API at the expected path and render the four required states (`VERIFIED`, `REVOKED`, `EXPIRED`, `NOT_FOUND`).

### Description

- Added `lib/app-role.ts` to expose `getAppRole()`, `isVerifyRole()`, and `isIssuerRole()` driven by `NEXT_PUBLIC_APP_ROLE`.  
- Role-based routing: updated `app/page.tsx` to redirect to `/login` when role is `issuer`, and updated `app/[qrvid]/page.tsx` to return `notFound()` when deployed as `issuer`.  
- Middleware changes route requests based on role and allow the verify role to serve `/` and single-segment record paths; issuer role retains the login redirect and auth checks.  
- Updated verification client in `lib/verification.ts` to call `GET ${process.env.NEXT_PUBLIC_QRV_API_BASE_URL}/api/v1/verify/{qrvid}` and preserve normalization for `VERIFIED`, `REVOKED`, `EXPIRED`, and `NOT_FOUND`.  
- Added sample landing link to `/QRV-PROD-CERT-000001`, a deployment runbook at `docs/verify-domain-deployment.md`, and a smoke script `scripts/verify-domain-smoke.mjs` plus `npm` script `smoke:verify-domain` to validate root/seeded/unknown UI responses.  
- Documented app-role behavior in `README.md`.

### Testing

- Ran unit and route smoke tests with `npm test` (vitest) and all tests passed (`5 files, 23 tests`).  
- Built the Next.js app with `npm run build` and the production build completed successfully.  
- Added `npm run smoke:verify-domain` (script `scripts/verify-domain-smoke.mjs`) for post-deploy checks but did not run it in this CI; it verifies that `/` returns HTML, seeded QRVID returns `VERIFIED`, and unknown QRVID returns `NOT_FOUND`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1479af30832d807ab10c7fbe8d71)