### PR TITLE
Add public verification landing, role-based routing, and verification API normalization

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,9 +57,43 @@ body {
   margin-top: 1rem;
   color: var(--navy-950);
   background: linear-gradient(135deg, var(--gold-300), var(--gold-500));
+  border: 0;
   border-radius: 999px;
   font-weight: 700;
   padding: 0.68rem 1rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.secondary-link {
+  display: inline-block;
+  margin-top: 0.8rem;
+  color: #dbe7ff;
+  text-decoration: underline;
+}
+
+.verify-search {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.verify-input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(0, 8, 20, 0.28);
+  color: var(--white);
+}
+
+.verify-input::placeholder {
+  color: #b0c1e6;
+}
+
+.service-panel h1 {
+  margin: 0.25rem 0;
+  font-size: clamp(1.2rem, 5vw, 1.6rem);
 }
 
 .verify-header {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,13 @@
-import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { PublicVerifyLanding } from '@/components/verify/PublicVerifyLanding';
+import { getAppRole } from '@/lib/app-role';
 
 export default function HomePage() {
-  return (
-    <main className="page-wrap">
-      <section className="verify-card hero-card">
-        <p className="eyebrow">QRV Public Verification</p>
-        <h1>Trust every credential before you rely on it.</h1>
-        <p className="hero-copy">
-          Open a verification URL in the format <span className="mono">/your-qrvid</span> to view
-          issuer, ownership, hash, and status details directly from the QRV registry.
-        </p>
-        <Link href="/sample-qrvid" className="primary-link" prefetch={false}>
-          Try sample route
-        </Link>
-      </section>
-    </main>
-  );
+  const role = getAppRole();
+
+  if (role === 'issuer') {
+    redirect('/login');
+  }
+
+  return <PublicVerifyLanding />;
 }

--- a/components/verify/PublicVerifyLanding.tsx
+++ b/components/verify/PublicVerifyLanding.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export function PublicVerifyLanding() {
+  const [qrvid, setQrvid] = useState('');
+  const router = useRouter();
+
+  function handleOpenQrvid() {
+    const trimmedQrvid = qrvid.trim();
+    if (!trimmedQrvid) {
+      return;
+    }
+    router.push(`/${encodeURIComponent(trimmedQrvid)}`);
+  }
+
+  return (
+    <main className="page-wrap">
+      <section className="verify-card hero-card">
+        <p className="eyebrow">QRV Public Verification</p>
+        <h1>Trust every credential before you rely on it.</h1>
+        <p className="hero-copy">Enter a QRVID to check its public verification status.</p>
+
+        <div className="verify-search" role="search" aria-label="QRVID verification">
+          <label htmlFor="qrvid" className="field-label">
+            Enter a QRVID
+          </label>
+          <input
+            id="qrvid"
+            className="verify-input"
+            placeholder="QRV-PROD-CERT-000001"
+            value={qrvid}
+            onChange={(event) => setQrvid(event.target.value)}
+          />
+          <button type="button" className="primary-link" onClick={handleOpenQrvid}>
+            Open verification route
+          </button>
+        </div>
+
+        <Link href="/QRV-PROD-CERT-000001" className="secondary-link" prefetch={false}>
+          Try sample route: /QRV-PROD-CERT-000001
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/components/verify/VerifyView.tsx
+++ b/components/verify/VerifyView.tsx
@@ -39,6 +39,22 @@ function Field({ label, value, mono = false }: { label: string; value: string; m
 }
 
 export function VerifyView({ record }: Props) {
+  if (record.apiUnavailable) {
+    return (
+      <main className="page-wrap">
+        <section className="verify-card service-panel">
+          <p className="eyebrow">QRV Registry Verification</p>
+          <h1>Verification service is temporarily unavailable</h1>
+          <p className="status-message">
+            We could not reach the verification API right now. Please retry in a moment.
+          </p>
+          <Field label="QRVID" value={record.qrvid} mono />
+          <Field label="Verification Timestamp" value={formatDate(record.verifiedAt)} />
+        </section>
+      </main>
+    );
+  }
+
   const status = STATUS_LABELS[record.status];
 
   return (
@@ -65,6 +81,7 @@ export function VerifyView({ record }: Props) {
         </section>
 
         <section className="fields-grid" aria-label="verification details">
+          <Field label="Record Type" value={record.recordType ?? 'Unavailable'} />
           <Field label="Credential Title" value={record.credentialTitle} />
           <Field label="Subject" value={record.subjectDisplay} />
           <Field label="Issued Date" value={formatDate(record.issuedAt)} />

--- a/docs/domain-role-map.md
+++ b/docs/domain-role-map.md
@@ -1,0 +1,6 @@
+# QRV Domain Role Map
+
+- `issuer.qrv.network` = `NEXT_PUBLIC_APP_ROLE=issuer`
+- `verify.qrv.network` = `NEXT_PUBLIC_APP_ROLE=verify`
+- `api.qrv.network` = Express API
+- `registry.qrv.network` = registry/status service

--- a/lib/app-role.ts
+++ b/lib/app-role.ts
@@ -1,0 +1,6 @@
+export type AppRole = 'issuer' | 'verify';
+
+export function getAppRole(): AppRole {
+  const rawRole = process.env.NEXT_PUBLIC_APP_ROLE?.trim().toLowerCase();
+  return rawRole === 'verify' ? 'verify' : 'issuer';
+}

--- a/lib/verification.ts
+++ b/lib/verification.ts
@@ -4,15 +4,17 @@ export type VerificationRecord = {
   status: VerifyStatus;
   issuerName: string;
   issuerLogoUrl?: string;
+  recordType?: string;
   credentialTitle: string;
   subjectDisplay: string;
   issuedAt: string;
   verifiedAt: string;
   proofReference: string;
   qrvid: string;
+  apiUnavailable?: boolean;
 };
 
-const VERIFY_API_BASE_URL = process.env.NEXT_PUBLIC_QRV_VERIFY_API_BASE_URL ?? 'https://api.qrv.network/verify';
+const VERIFY_API_BASE_URL = process.env.NEXT_PUBLIC_QRV_API_BASE_URL ?? 'https://api.qrv.network';
 
 function asText(value: unknown, fallback = 'Unavailable') {
   return typeof value === 'string' && value.trim() ? value : fallback;
@@ -35,7 +37,7 @@ export async function fetchVerification(qrvid: string): Promise<VerificationReco
   const verifiedAt = new Date().toISOString();
 
   try {
-    const response = await fetch(`${VERIFY_API_BASE_URL}/${encodedQrvid}`, {
+    const response = await fetch(`${VERIFY_API_BASE_URL}/api/v1/verify/${encodedQrvid}`, {
       method: 'GET',
       cache: 'no-store',
       headers: {
@@ -47,6 +49,7 @@ export async function fetchVerification(qrvid: string): Promise<VerificationReco
       return {
         status: 'NOT_FOUND',
         issuerName: 'Unavailable',
+        recordType: 'Unavailable',
         credentialTitle: 'Unavailable',
         subjectDisplay: 'Unavailable',
         issuedAt: 'Unavailable',
@@ -60,26 +63,31 @@ export async function fetchVerification(qrvid: string): Promise<VerificationReco
       return {
         status: 'NOT_FOUND',
         issuerName: 'Unavailable',
+        recordType: 'Unavailable',
         credentialTitle: 'Unavailable',
         subjectDisplay: 'Unavailable',
         issuedAt: 'Unavailable',
         verifiedAt,
         proofReference: 'Unavailable',
         qrvid,
+        apiUnavailable: true,
       };
     }
 
-    const data: Record<string, unknown> = await response.json();
-    const issuerLogoUrl = typeof data.issuerLogoUrl === 'string'
-      ? data.issuerLogoUrl
-      : typeof data.issuer_logo_url === 'string'
-        ? data.issuer_logo_url
-        : undefined;
+    const rawJson = (await response.json()) as Record<string, unknown>;
+    const data = typeof rawJson.data === 'object' && rawJson.data ? (rawJson.data as Record<string, unknown>) : rawJson;
+    const issuerLogoUrl =
+      typeof data.issuerLogoUrl === 'string'
+        ? data.issuerLogoUrl
+        : typeof data.issuer_logo_url === 'string'
+          ? data.issuer_logo_url
+          : undefined;
 
     return {
       status: normalizeStatus(data.status),
       issuerName: asText(data.issuerName ?? data.issuer),
       issuerLogoUrl,
+      recordType: asText(data.recordType ?? data.record_type ?? data.type),
       credentialTitle: asText(data.credentialTitle ?? data.title),
       subjectDisplay: asText(data.subjectDisplay ?? data.recipientName ?? data.subject),
       issuedAt: asText(data.issuedAt ?? data.issueDate ?? data.created_at),
@@ -91,12 +99,14 @@ export async function fetchVerification(qrvid: string): Promise<VerificationReco
     return {
       status: 'NOT_FOUND',
       issuerName: 'Unavailable',
+      recordType: 'Unavailable',
       credentialTitle: 'Unavailable',
       subjectDisplay: 'Unavailable',
       issuedAt: 'Unavailable',
       verifiedAt,
       proofReference: 'Unavailable',
       qrvid,
+      apiUnavailable: true,
     };
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,19 +1,47 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getAppRole } from '@/lib/app-role';
 
 const PUBLIC_PATHS = ['/', '/login', '/healthz', '/readyz', '/version'];
+const VERIFY_BLOCKED_PATHS = ['/dashboard', '/certificates', '/api-keys', '/settings', '/login'];
+
+function isStaticPath(pathname: string): boolean {
+  return pathname.startsWith('/_next') || pathname.startsWith('/favicon') || pathname.includes('.');
+}
 
 function isPublicPath(pathname: string): boolean {
-  return (
-    PUBLIC_PATHS.includes(pathname) ||
-    pathname.startsWith('/_next') ||
-    pathname.startsWith('/favicon') ||
-    pathname.startsWith('/api') ||
-    pathname.includes('.')
-  );
+  return PUBLIC_PATHS.includes(pathname) || pathname.startsWith('/api') || isStaticPath(pathname);
+}
+
+function isIssuerOnlyPath(pathname: string): boolean {
+  return VERIFY_BLOCKED_PATHS.some((basePath) => pathname === basePath || pathname.startsWith(`${basePath}/`));
+}
+
+function isVerifyPublicPath(pathname: string): boolean {
+  if (pathname === '/') return true;
+  if (pathname === '/healthz' || pathname === '/readyz' || pathname === '/version') return true;
+  if (pathname.startsWith('/api')) return true;
+
+  const segments = pathname.split('/').filter(Boolean);
+  return segments.length === 1;
 }
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const role = getAppRole();
+
+  if (isStaticPath(pathname)) {
+    return NextResponse.next();
+  }
+
+  if (role === 'verify') {
+    if (isIssuerOnlyPath(pathname)) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+    if (!isVerifyPublicPath(pathname)) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+    return NextResponse.next();
+  }
 
   if (isPublicPath(pathname)) {
     return NextResponse.next();


### PR DESCRIPTION
### Motivation

- Provide a public-facing verification landing experience and enforce domain-based app roles to route users appropriately.
- Make the verification client tolerant to API shape differences and surface API availability to users.

### Description

- Introduce a new `PublicVerifyLanding` client component and wire `app/page.tsx` to redirect issuer-role hosts to `/login` while serving the public landing for verify-role hosts via `getAppRole` from `lib/app-role.ts`.
- Add role-aware middleware changes in `middleware.ts` to allow static and public verify routes, block issuer-only routes for verify-role hosts, and centralize static path handling.
- Harden verification fetching in `lib/verification.ts` by adjusting the API base URL, calling `/api/v1/verify/<qrvid>`, unpacking wrapped `data` responses, normalizing fields (including `recordType`), and flagging `apiUnavailable` on errors or network exceptions.
- Update the verification UI in `components/verify/VerifyView.tsx` to show a service-unavailable state when the API is unreachable and display `Record Type`, and add a new `globals.css` styles for the landing, search input, links, and service panel; also add `docs/domain-role-map.md` for role mapping.

### Testing

- Ran a TypeScript type-check and project build with `npm run build` which completed successfully.
- Validated the public landing and verification flow in the dev server (`npm run dev`) to confirm navigation, input-driven route opening, and the API-unavailable UI render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1693da8c832d903fd5494c7755ce)