### PR TITLE
Add HOST_ROLE routing, JSON verify API, QRVID normalization, and security improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ npm run dev
 
 - `PORT` (provided by Hostinger at runtime)
 - `NODE_ENV=production`
+- `HOST_ROLE=verify` for verify.qrv.network (`issuer` for issuer.qrv.network, `api` for API-only host)
 - `DATABASE_URL`
 - `SIGNING_SECRET`
 - `ISSUER_TOKEN`
@@ -106,6 +107,7 @@ npm run dev
 - `GET https://verify.qrv.network/version`
 - `GET https://verify.qrv.network/QRV-PROD-CERT-000001`
 - `GET https://verify.qrv.network/verify/QRV-PROD-CERT-000001`
+- `GET https://verify.qrv.network/api/v1/verify/QRV-PROD-CERT-000001`
 - `GET https://verify.qrv.network/this-route-should-404`
 
 ### Post-merge release flow
@@ -143,5 +145,12 @@ This Next.js app supports two deployment roles via `NEXT_PUBLIC_APP_ROLE`:
 Verification records are fetched from:
 
 - `${NEXT_PUBLIC_QRV_API_BASE_URL}/api/v1/verify/{qrvid}`
+
+## Production host mapping
+
+- `issuer.qrv.network` → Issuer control plane (`/` redirects to `/login`)
+- `verify.qrv.network` → Public verification portal (`/` is branded public verify landing)
+- `api.qrv.network` → API endpoints / JSON services
+- `registry.qrv.network` → Registry service
 
 See `docs/verify-domain-deployment.md` for host/domain rollout steps.

--- a/docs/verify-domain-deployment.md
+++ b/docs/verify-domain-deployment.md
@@ -2,11 +2,14 @@
 
 This guide documents the **canonical production setup** now that the branded verification portal is merged to `main`.
 
+> Current-state note: this repo can serve `verify.qrv.network` today because it contains the branded verify routes. Long-term, split public verification into its own dedicated repository.
+
 ## 1) Deploy source of truth
 
 - Deploy **branch `main`** for `verify.qrv.network`.
 - The public verify portal is served by the Node/Express service (`npm run start:server`).
 - Do not deploy stale feature branches for production verify traffic.
+- Do not point `verify.qrv.network` at issuer-only runtimes that redirect `/` to `/login`.
 
 ## 2) Hostinger settings (production)
 
@@ -22,6 +25,7 @@ Use the following project settings:
 
 ```bash
 NODE_ENV=production
+HOST_ROLE=verify
 DATABASE_URL=...
 SIGNING_SECRET=...
 ISSUER_TOKEN=...
@@ -44,12 +48,14 @@ Validate these exact URLs after every redeploy:
 3. `https://verify.qrv.network/version`
 4. `https://verify.qrv.network/QRV-PROD-CERT-000001`
 5. `https://verify.qrv.network/verify/QRV-PROD-CERT-000001`
-6. `https://verify.qrv.network/random-bad-route`
+6. `https://verify.qrv.network/api/v1/verify/QRV-PROD-CERT-000001`
+7. `https://verify.qrv.network/random-bad-route`
 
 Expected outcomes:
 
-- `/` contains `QR-V™ Verification Portal`.
+- `/` contains `QRV Public Verification`.
 - `/healthz` and `/version` return JSON.
+- `/api/v1/verify/:qrvid` returns JSON status with normalized QRVID handling.
 - QRVID paths return branded HTML result pages (not plain `Not found` text).
 - Unknown routes return branded 404 HTML.
 

--- a/scripts/verify-domain-smoke.mjs
+++ b/scripts/verify-domain-smoke.mjs
@@ -33,10 +33,38 @@ async function expectHtml(pathname, requiredText) {
   return { url, status: response.status, contentType };
 }
 
+async function expectJson(pathname, expectedStatus) {
+  const url = `${VERIFY_BASE_URL}${pathname}`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok && response.status !== 404 && response.status !== 400) {
+    throw new Error(`GET ${url} failed (${response.status})`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) {
+    throw new Error(`GET ${url} returned non-JSON content-type '${contentType}'`);
+  }
+
+  const body = await response.json();
+  if (body.status !== expectedStatus) {
+    throw new Error(`GET ${url} expected status '${expectedStatus}' and received '${body.status}'`);
+  }
+
+  return { url, status: response.status, body };
+}
+
 async function run() {
   const root = await expectHtml('/', 'QRV Public Verification');
   const seeded = await expectHtml(`/${encodeURIComponent(SEEDED_QRVID)}`, 'VERIFIED');
   const unknown = await expectHtml(`/${encodeURIComponent(UNKNOWN_QRVID)}`, 'NOT_FOUND');
+  const seededJson = await expectJson(`/api/v1/verify/${encodeURIComponent(SEEDED_QRVID)}`, 'VERIFIED');
+  const unknownJson = await expectJson(`/api/v1/verify/${encodeURIComponent(UNKNOWN_QRVID)}`, 'NOT_FOUND');
+  const invalidJson = await expectJson('/api/v1/verify/%20bad%20id%20', 'INVALID_FORMAT');
 
   console.log('Verify-domain smoke checks passed');
   console.log(
@@ -45,7 +73,7 @@ async function run() {
         verifyBaseUrl: VERIFY_BASE_URL,
         seededQrvid: SEEDED_QRVID,
         unknownQrvid: UNKNOWN_QRVID,
-        checks: { root, seeded, unknown },
+        checks: { root, seeded, unknown, seededJson, unknownJson, invalidJson },
       },
       null,
       2,

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const QRCode = require('qrcode');
 const { v4: uuidv4 } = require('uuid');
 const { Pool } = require('pg');
+const crypto = require('crypto');
 
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || process.env.ADMIN_API_KEY;
 const ISSUER_TOKEN = process.env.ISSUER_TOKEN || process.env.ISSUER_API_KEY_SECRET;
@@ -11,12 +12,15 @@ const SIGNING_SECRET = process.env.SIGNING_SECRET || process.env.QRV_SIGNING_SEC
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const IS_PRODUCTION = NODE_ENV === 'production';
+const HOST_ROLE = String(process.env.HOST_ROLE || 'verify').toLowerCase();
 
 const PORT = Number(process.env.PORT || 3000);
 const DATABASE_URL = process.env.DATABASE_URL;
 const APP_BASE_URL = process.env.APP_BASE_URL || 'https://issuer.qrv.network';
+const ISSUER_LOGIN_PATH = process.env.ISSUER_LOGIN_PATH || '/login';
 const RATE_LIMIT_WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000);
 const RATE_LIMIT_MAX = Number(process.env.RATE_LIMIT_MAX || 100);
+const VALID_HOST_ROLES = new Set(['issuer', 'verify', 'api']);
 
 if (!process.env.ADMIN_TOKEN && process.env.ADMIN_API_KEY) {
   console.warn('[config] ADMIN_API_KEY is deprecated, prefer ADMIN_TOKEN');
@@ -38,6 +42,7 @@ function getConfigIssues() {
   if (!ISSUER_TOKEN) issues.push('ISSUER_TOKEN (or ISSUER_API_KEY_SECRET) is missing');
   if (!JWT_SECRET) issues.push('JWT_SECRET (or ISSUER_JWT_SECRET) is missing');
   if (!ADMIN_TOKEN) issues.push('ADMIN_TOKEN (or ADMIN_API_KEY) is missing');
+  if (!VALID_HOST_ROLES.has(HOST_ROLE)) issues.push('HOST_ROLE must be issuer, verify, or api');
   return issues;
 }
 
@@ -47,6 +52,7 @@ const pool = new Pool({
 });
 
 const app = express();
+app.disable('x-powered-by');
 app.use(cors());
 app.use(express.json());
 
@@ -99,7 +105,13 @@ const QRVID_FORMAT = /^[A-Z0-9][A-Z0-9-]{5,127}$/;
 function authByToken(expectedToken) {
   return (req, res, next) => {
     const token = req.headers.authorization?.replace(/^Bearer\s+/i, '').trim();
-    if (!token || token !== expectedToken) {
+    const tokenBuffer = Buffer.from(String(token || ''), 'utf8');
+    const expectedBuffer = Buffer.from(String(expectedToken || ''), 'utf8');
+    const valid =
+      expectedBuffer.length > 0 &&
+      expectedBuffer.length === tokenBuffer.length &&
+      crypto.timingSafeEqual(expectedBuffer, tokenBuffer);
+    if (!valid) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
     return next();
@@ -184,6 +196,15 @@ async function readRecordById(qrvid) {
   }
 }
 
+function normalizeQrvid(rawValue) {
+  try {
+    const decoded = decodeURIComponent(String(rawValue || '').trim());
+    return decoded.toUpperCase().replace(/\s+/g, '');
+  } catch (_error) {
+    return '';
+  }
+}
+
 function escapeHtml(value) {
   return String(value ?? '')
     .replace(/&/g, '&amp;')
@@ -225,11 +246,32 @@ function renderLayout({ title, body }) {
 }
 
 function renderPortalHome() {
+  if (HOST_ROLE === 'api') {
+    return renderLayout({
+      title: 'QR-V™ API Surface',
+      body: `
+      <section class="card">
+        <h1>QR-V™ API Surface</h1>
+        <p class="muted">This deployment is API-only. Use issuer.qrv.network for issuer UI and verify.qrv.network for public verification.</p>
+        <div class="links">
+          <a href="/healthz">/healthz</a>
+          <a href="/readyz">/readyz</a>
+          <a href="/version">/version</a>
+          <a href="/api/v1/verify/QRV-PROD-CERT-000001">/api/v1/verify/:qrvid</a>
+        </div>
+      </section>`
+    });
+  }
+
+  if (HOST_ROLE === 'issuer') {
+    return null;
+  }
+
   return renderLayout({
-    title: 'QR-V™ Verification Portal',
+    title: 'QR-V™ Public Verification',
     body: `
     <section class="card">
-      <h1>QR-V™ Verification Portal</h1>
+      <h1>QRV Public Verification</h1>
       <p class="muted">Authenticate certificates, credentials, products, and registry-backed records</p>
       <form class="row" action="/verify" method="get" onsubmit="event.preventDefault();const v=document.getElementById('qrvid').value.trim();if(v){window.location='/' + encodeURIComponent(v);}">
         <input id="qrvid" name="qrvid" type="text" required placeholder="Enter QRVID (for example: QRV-PROD-CERT-000001)" />
@@ -381,6 +423,32 @@ async function getVerificationState(qrvid) {
   }
 }
 
+async function resolveVerification(qrvidRaw) {
+  const qrvid = normalizeQrvid(qrvidRaw);
+  const verifiedAt = new Date().toISOString();
+  const payload = await getVerificationState(qrvid);
+  const statusCodeByState = {
+    VERIFIED: 200,
+    REVOKED: 200,
+    EXPIRED: 200,
+    INVALID_FORMAT: 400,
+    NOT_FOUND: 404,
+    UNAVAILABLE: 503
+  };
+
+  return {
+    qrvid,
+    payload,
+    body: {
+      qrvid,
+      status: payload.state,
+      message: payload.message,
+      verifiedAt
+    },
+    statusCode: statusCodeByState[payload.state] || 500
+  };
+}
+
 function renderVerificationPage(qrvid, payload) {
   const { state, message, record } = payload;
   const metadata = record
@@ -465,13 +533,19 @@ app.get('/records/:id', async (req, res) => {
 });
 
 app.get('/verify/:id', async (req, res) => {
-  const qrvid = req.params.id;
-  const payload = await getVerificationState(qrvid);
-  const statusCode = payload.state === 'VERIFIED' ? 200 : payload.state === 'UNAVAILABLE' ? 503 : 404;
+  const { qrvid, payload, statusCode } = await resolveVerification(req.params.id);
   return res.status(statusCode).type('html').send(renderVerificationPage(qrvid, payload));
 });
 
+app.get('/api/v1/verify/:qrvid', async (req, res) => {
+  const { body, statusCode } = await resolveVerification(req.params.qrvid);
+  return res.status(statusCode).json(body);
+});
+
 app.get('/', (_req, res) => {
+  if (HOST_ROLE === 'issuer') {
+    return res.redirect(302, ISSUER_LOGIN_PATH);
+  }
   res.type('html').send(renderPortalHome());
 });
 
@@ -484,9 +558,7 @@ app.get('/:qrvid', async (req, res, next) => {
     return next();
   }
 
-  const qrvid = req.params.qrvid;
-  const payload = await getVerificationState(qrvid);
-  const statusCode = payload.state === 'VERIFIED' ? 200 : payload.state === 'UNAVAILABLE' ? 503 : 404;
+  const { qrvid, payload, statusCode } = await resolveVerification(req.params.qrvid);
   return res.status(statusCode).type('html').send(renderVerificationPage(qrvid, payload));
 });
 
@@ -516,6 +588,13 @@ async function runProductionSmokeCheck() {
 }
 
 async function start() {
+  if (IS_PRODUCTION && !DATABASE_URL) {
+    throw new Error('DATABASE_URL is required in production');
+  }
+  if (!VALID_HOST_ROLES.has(HOST_ROLE)) {
+    throw new Error(`Invalid HOST_ROLE '${HOST_ROLE}'. Allowed values: issuer, verify, api`);
+  }
+
   await migrateCertificateV1();
 
   if (process.env.RUN_SMOKE_CHECK === '1') {
@@ -523,7 +602,7 @@ async function start() {
   }
 
   app.listen(PORT, '0.0.0.0', () => {
-    console.log(`QR-V server running on 0.0.0.0:${PORT}`);
+    console.log(`QR-V server running on 0.0.0.0:${PORT} role=${HOST_ROLE}`);
   });
 }
 
@@ -539,5 +618,7 @@ module.exports = {
   start,
   migrateCertificateV1,
   runProductionSmokeCheck,
-  getConfigIssues
+  getConfigIssues,
+  normalizeQrvid,
+  resolveVerification
 };


### PR DESCRIPTION
### Motivation

- Support multiple deployment roles (issuer, verify, api) from the same codebase and document production host mapping. 
- Provide a machine-friendly JSON verification endpoint alongside the existing HTML portal and improve deterministic QRVID handling. 
- Harden token auth and startup/runtime checks to reduce accidental misconfiguration in production.

### Description

- Introduce `HOST_ROLE` env var and validate allowed values via `VALID_HOST_ROLES`, add `ISSUER_LOGIN_PATH`, and change root behavior to redirect for `issuer` or render API-only content for `api`. 
- Add `/api/v1/verify/:qrvid` JSON endpoint and centralize verification logic in `resolveVerification`, plus `normalizeQrvid` to decode, uppercase, and trim input. 
- Replace naive token equality with timing-safe comparison using `crypto.timingSafeEqual` in `authByToken` and disable the `x-powered-by` header. 
- Enforce `DATABASE_URL` presence in production, keep in-memory fallback disabled for prod, and expose `normalizeQrvid`/`resolveVerification` from module exports. 
- Update HTML rendering texts for public portal branding, add host mapping and environment docs in `README.md` and `docs/verify-domain-deployment.md`, and extend `scripts/verify-domain-smoke.mjs` to validate JSON endpoints and normalized QRVID handling. 

### Testing

- Ran `npm run check` to exercise quality gates and static checks and it completed successfully. 
- Executed the domain smoke script via `node scripts/verify-domain-smoke.mjs` against the verify base URL to validate HTML and JSON verify routes and it passed. 
- Started the server locally and exercised `/`, `/healthz`, `/version`, `/api/v1/verify/:qrvid`, and HTML verify routes to confirm expected responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee17d7965c832d9f500e5773d030e2)