### PR TITLE
docs: codify verify V1 canonical routing and live smoke checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Canonical public trust layer for **verify.qrv.network** built with Next.js + Typ
 
 - `/` — landing page with QRVID input and trust explainer
 - `/verify/[qrvid]` — public verification result
+- `/[qrvid]` — legacy single-segment route redirected to `/verify/[qrvid]`
 - `/scan` — scanner placeholder
 - `/help` — public help and interpretation guide
 - `/api-status` — API contract and endpoint status reference
@@ -63,3 +64,26 @@ npm run dev
 - Build command: `npm run build`
 - Start command: `npm run start`
 - Configure host `verify.qrv.network` with `NEXT_PUBLIC_APP_ROLE=verify`.
+- Canonical public URL format is `https://verify.qrv.network/verify/:qrvid` (legacy `/:qrvid` is retained for compatibility).
+
+## Production V1 live validation
+
+Run a quick public smoke test on the deployed domain:
+
+- `https://verify.qrv.network`
+- `https://verify.qrv.network/scan`
+- `https://verify.qrv.network/help`
+- `https://verify.qrv.network/api-status`
+- `https://verify.qrv.network/verify/QRV-TEST-001`
+- `https://verify.qrv.network/QRV-TEST-001`
+
+Acceptance checks:
+
+1. Valid QRVID input normalizes and routes to `/verify/:qrvid`.
+2. `/QRV-...` legacy path redirects to `/verify/QRV-...`.
+3. Verification fetches `GET https://api.qrv.network/verify/:qrvid`.
+4. `VERIFIED`, `NOT_FOUND`, `INVALID_FORMAT`, and `UNAVAILABLE` states render with public-safe messaging.
+5. "Copy canonical URL" uses `https://verify.qrv.network/verify/:qrvid`.
+6. Issuer CTA opens `issuer.qrv.network`.
+7. Mobile layout remains readable and actionable.
+8. Raw backend/internal errors are not exposed.

--- a/docs/qrv-live-domain-smoke-checklist.md
+++ b/docs/qrv-live-domain-smoke-checklist.md
@@ -27,7 +27,7 @@ Set the following before running production validation:
 
 - `issuer.qrv.network` resolves to issuer portal deployment.
 - `api.qrv.network` resolves to API deployment with `/healthz`, `/readyz`, `/certificates`, and revocation routes.
-- `verify.qrv.network` resolves to the public verification UI and supports path-based lookup (`/{qrvid}`).
+- `verify.qrv.network` resolves to the public verification UI with canonical lookup at `/verify/{qrvid}` and legacy compatibility at `/{qrvid}`.
 - TLS is enabled for all three domains.
 
 ## Migration-first requirement
@@ -54,7 +54,21 @@ npm run smoke:e2e
 - Revocation succeeds.
 - Verification resolves to `REVOKED` after revocation.
 - Missing QRVID resolves to `NOT_FOUND`.
-- Seeded record `QRV-PROD-CERT-000001` resolves at `https://verify.qrv.network/QRV-PROD-CERT-000001` with public status `VERIFIED`.
+- Invalid QRVID format renders `INVALID_FORMAT` (public-safe error state).
+- Upstream/API interruption renders `UNAVAILABLE` (public-safe error state).
+- Seeded record `QRV-PROD-CERT-000001` resolves at `https://verify.qrv.network/verify/QRV-PROD-CERT-000001` with public status `VERIFIED`.
+- Legacy path `https://verify.qrv.network/QRV-PROD-CERT-000001` redirects to canonical `/verify/QRV-PROD-CERT-000001`.
+
+## Public smoke URLs
+
+Run at least one manual browser pass against:
+
+- `https://verify.qrv.network`
+- `https://verify.qrv.network/scan`
+- `https://verify.qrv.network/help`
+- `https://verify.qrv.network/api-status`
+- `https://verify.qrv.network/verify/QRV-TEST-001`
+- `https://verify.qrv.network/QRV-TEST-001`
 
 ## Rollback criteria
 


### PR DESCRIPTION
### Motivation

- Clarify the public verification surface so production routing is canonicalized to `/verify/:qrvid` while preserving legacy single-segment compatibility at `/:qrvid`.
- Make the README and live-domain smoke checklist explicit about the public smoke URLs and acceptance criteria required for a Production V1 verification node.
- Document the expected public-safe verification states including `INVALID_FORMAT` and `UNAVAILABLE` to align UI behavior with upstream/API failure modes.

### Description

- Updated `README.md` to list the legacy `/:qrvid` path and add a `Production V1 live validation` section with canonical URL guidance and manual smoke-test URLs.
- Updated `docs/qrv-live-domain-smoke-checklist.md` to require canonical `/verify/{qrvid}` lookups while retaining legacy compatibility and to add `INVALID_FORMAT` and `UNAVAILABLE` as expected public states.
- Added explicit acceptance checks and public smoke URL list to ensure deployed-domain manual validation focuses on normalization, redirect behavior, API contract, and public-safe rendering.
- This change is documentation-only and does not modify runtime application code.

### Testing

- Ran `npm test` which executed the Vitest suite and all tests passed (`7 files, 28 tests` passed).
- Ran `npm run lint` which reported no ESLint warnings or errors.
- Attempted `npm run -s test -- --runInBand` which failed due to an unsupported Vitest CLI option (`--runInBand`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef55689c88832db97570aa56fa03ac)