### PR TITLE
Refactor verification logic, middleware routing, and homepage to use PublicVerifyLanding

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,4 @@
 import { redirect } from 'next/navigation';
-import { getAppRole } from '@/lib/app-role';
-
-export default function HomePage() {
-  const role = getAppRole();
-
-  if (role === 'issuer') {
-    redirect('/login');
-  }
-
-  return (
-    <main className="page-wrap">
-      <section className="verify-card hero-card">
-        <p className="eyebrow">QRV Public Verification</p>
-        <h1>Trust every credential before you rely on it.</h1>
-      </section>
-    </main>
-  );
 import { PublicVerifyLanding } from '@/components/verify/PublicVerifyLanding';
 import { isIssuerRole } from '@/lib/app-role';
 

--- a/lib/verification.ts
+++ b/lib/verification.ts
@@ -1,6 +1,4 @@
-import { QRV_API_BASE_URL } from '@/lib/runtime-config';
-
-export type VerifyStatus = 'VERIFIED' | 'REVOKED' | 'EXPIRED' | 'NOT_FOUND';
+import { QRV_API_BASE_URL, QRV_VERIFY_BASE_URL } from '@/lib/runtime-config';
 import { normalizeQrvidInput } from '@/lib/verify-input';
 
 export type VerificationStatus =
@@ -24,9 +22,6 @@ export type VerificationRecord = {
   checkedAt: string;
 };
 
-const VERIFY_API_BASE_URL = QRV_API_BASE_URL;
-const API_BASE = process.env.NEXT_PUBLIC_QRV_API_BASE ?? 'https://api.qrv.network';
-
 const DEFAULTS: Omit<VerificationRecord, 'qrvid' | 'status' | 'checkedAt'> = {
   recordType: 'Unavailable',
   issuer: 'Unavailable',
@@ -45,29 +40,31 @@ function safeText(value: unknown, fallback = 'Unavailable'): string {
 
 function normalizeStatus(raw: unknown): VerificationStatus {
   const value = safeText(raw, 'UNAVAILABLE').toUpperCase();
-  if (['VERIFIED', 'REVOKED', 'EXPIRED', 'NOT_FOUND'].includes(value)) {
-    return value as VerificationStatus;
+  if (value === 'VERIFIED' || value === 'REVOKED' || value === 'EXPIRED' || value === 'NOT_FOUND') {
+    return value;
   }
+
   return 'UNAVAILABLE';
 }
 
 function canonicalFor(qrvid: string): string {
-  return `https://verify.qrv.network/verify/${encodeURIComponent(qrvid)}`;
+  return `${QRV_VERIFY_BASE_URL}/verify/${encodeURIComponent(qrvid)}`;
 }
 
-function getUnavailableRecord(qrvid: string, verifiedAt: string): VerificationRecord {
+function unavailableRecord(
+  qrvid: string,
+  status: Extract<VerificationStatus, 'NOT_FOUND' | 'UNAVAILABLE'>,
+  checkedAt: string,
+): VerificationRecord {
   return {
-    status: 'NOT_FOUND',
-    issuerName: 'Unavailable',
-    credentialTitle: 'Unavailable',
-    subjectDisplay: 'Unavailable',
-    issuedAt: 'Unavailable',
-    verifiedAt,
-    proofReference: 'Unavailable',
+    ...DEFAULTS,
     qrvid,
-    apiUnavailable: true,
+    status,
+    checkedAt,
+    canonicalUrl: canonicalFor(qrvid),
   };
 }
+
 export async function resolveVerification(rawInput: string): Promise<VerificationRecord> {
   const checkedAt = new Date().toISOString();
   const normalized = normalizeQrvidInput(rawInput);
@@ -85,92 +82,54 @@ export async function resolveVerification(rawInput: string): Promise<Verificatio
   const qrvid = normalized.qrvid;
 
   try {
-    const response = await fetch(`${API_BASE}/verify/${encodeURIComponent(qrvid)}`, {
+    const response = await fetch(`${QRV_API_BASE_URL}/verify/${encodeURIComponent(qrvid)}`, {
       method: 'GET',
       headers: { Accept: 'application/json' },
       cache: 'no-store',
-      headers: { Accept: 'application/json' },
-    });
-
-    if (!response.ok) {
-      return getUnavailableRecord(qrvid, verifiedAt);
-    }
-
-    const rawJson = (await response.json()) as Record<string, unknown>;
-    const data = typeof rawJson.data === 'object' && rawJson.data ? (rawJson.data as Record<string, unknown>) : rawJson;
-
-    return {
-      status: normalizeStatus(data.status),
-      issuerName: asText(data.issuerName ?? data.issuer),
-      issuerLogoUrl: typeof data.issuerLogoUrl === 'string' ? data.issuerLogoUrl : undefined,
-      recordType: asText(data.recordType ?? data.record_type ?? data.type),
-      credentialTitle: asText(data.credentialTitle ?? data.title),
-      subjectDisplay: asText(data.subjectDisplay ?? data.recipientName ?? data.subject),
-      issuedAt: asText(data.issuedAt ?? data.issueDate ?? data.created_at),
-      verifiedAt,
-      proofReference: deriveProofReference(data),
-      qrvid: asText(data.qrvid, qrvid),
-    };
-  } catch {
-    return getUnavailableRecord(qrvid, verifiedAt);
-  }
-}
-
-export function formatDate(rawDate: string): string {
-  const parsed = new Date(rawDate);
-  if (Number.isNaN(parsed.getTime())) return rawDate;
-
     });
 
     if (response.status === 404) {
-      return {
-        ...DEFAULTS,
-        qrvid,
-        status: 'NOT_FOUND',
-        checkedAt,
-        canonicalUrl: canonicalFor(qrvid),
-      };
+      return unavailableRecord(qrvid, 'NOT_FOUND', checkedAt);
     }
 
     if (!response.ok) {
-      return {
-        ...DEFAULTS,
-        qrvid,
-        status: 'UNAVAILABLE',
-        checkedAt,
-        canonicalUrl: canonicalFor(qrvid),
-      };
+      return unavailableRecord(qrvid, 'UNAVAILABLE', checkedAt);
     }
 
     const payload = (await response.json()) as Record<string, unknown>;
+    const data =
+      typeof payload.data === 'object' && payload.data !== null
+        ? (payload.data as Record<string, unknown>)
+        : payload;
 
     return {
-      qrvid,
-      status: normalizeStatus(payload.status),
-      recordType: safeText(payload.recordType),
-      issuer: safeText(payload.issuer),
-      subject: safeText(payload.subject),
-      issuedAt: safeText(payload.issuedAt),
-      expiresAt: typeof payload.expiresAt === 'string' ? safeText(payload.expiresAt) : null,
-      hash: safeText(payload.hash),
-      canonicalUrl: safeText(payload.canonicalUrl, canonicalFor(qrvid)),
-      checkedAt: safeText(payload.checkedAt, checkedAt),
+      qrvid: safeText(data.qrvid, qrvid),
+      status: normalizeStatus(data.status),
+      recordType: safeText(data.recordType ?? data.record_type ?? data.type),
+      issuer: safeText(data.issuer ?? data.issuerName),
+      subject: safeText(data.subject ?? data.subjectDisplay ?? data.recipientName),
+      issuedAt: safeText(data.issuedAt ?? data.issueDate ?? data.created_at),
+      expiresAt:
+        typeof data.expiresAt === 'string'
+          ? safeText(data.expiresAt)
+          : typeof data.expirationDate === 'string'
+            ? safeText(data.expirationDate)
+            : null,
+      hash: safeText(data.hash ?? data.proofReference),
+      canonicalUrl: safeText(data.canonicalUrl, canonicalFor(qrvid)),
+      checkedAt: safeText(data.checkedAt, checkedAt),
     };
   } catch {
-    return {
-      ...DEFAULTS,
-      qrvid,
-      status: 'UNAVAILABLE',
-      checkedAt,
-      canonicalUrl: canonicalFor(qrvid),
-    };
+    return unavailableRecord(qrvid, 'UNAVAILABLE', checkedAt);
   }
 }
 
 export function formatTimestamp(value: string | null): string {
   if (!value) return 'Not set';
+
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
+
   return new Intl.DateTimeFormat('en-US', {
     month: 'short',
     day: '2-digit',

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,28 +2,22 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAppRole } from '@/lib/app-role';
 
 const ISSUER_PUBLIC_PATHS = ['/login', '/healthz', '/readyz', '/version'];
-const VERIFY_PUBLIC_PATHS = ['/', '/healthz', '/readyz', '/version'];
-const VERIFY_BLOCKED_PREFIXES = ['/dashboard', '/certificates', '/api-keys', '/settings', '/onboarding', '/analytics', '/revocations'];
+const VERIFY_PUBLIC_PATHS = ['/', '/scan', '/help', '/api-status', '/healthz', '/readyz', '/version'];
+const VERIFY_BLOCKED_PREFIXES = [
+  '/dashboard',
+  '/certificates',
+  '/api-keys',
+  '/settings',
+  '/onboarding',
+  '/analytics',
+  '/revocations',
+];
 
-function isNextInternalPath(pathname: string): boolean {
-  return pathname.startsWith('/_next') || pathname.startsWith('/favicon') || pathname.startsWith('/api') || pathname.includes('.');
+function isInternalPath(pathname: string): boolean {
+  return pathname.startsWith('/_next') || pathname.startsWith('/api') || pathname.startsWith('/favicon') || pathname.includes('.');
 }
 
 function isVerifyRecordPath(pathname: string): boolean {
-
-function isInternalPath(pathname: string): boolean {
-  return pathname.startsWith('/_next') || pathname.startsWith('/api') || pathname.includes('.') || pathname.startsWith('/favicon');
-}
-
-function isVerifyPublicPath(pathname: string): boolean {
-  if (pathname === '/' || pathname === '/scan' || pathname === '/help' || pathname === '/api-status') {
-    return true;
-  }
-
-  if (pathname === '/healthz' || pathname === '/readyz' || pathname === '/version') {
-    return true;
-  }
-
   if (pathname.startsWith('/verify/')) {
     return true;
   }
@@ -38,13 +32,6 @@ function isBlockedVerifyPath(pathname: string): boolean {
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const appRole = getAppRole();
-
-  if (isNextInternalPath(pathname)) return NextResponse.next();
-
-  if (appRole === 'verify') {
-    if (VERIFY_PUBLIC_PATHS.includes(pathname) || isVerifyRecordPath(pathname)) return NextResponse.next();
-    if (isBlockedVerifyPath(pathname)) return NextResponse.redirect(new URL('/', request.url));
 
   if (isInternalPath(pathname)) {
     return NextResponse.next();
@@ -53,20 +40,26 @@ export function middleware(request: NextRequest) {
   const appRole = getAppRole();
 
   if (appRole === 'verify') {
-    if (isVerifyPublicPath(pathname)) {
+    if (VERIFY_PUBLIC_PATHS.includes(pathname) || isVerifyRecordPath(pathname)) {
       return NextResponse.next();
     }
+
+    if (isBlockedVerifyPath(pathname)) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  if (pathname === '/') return NextResponse.redirect(new URL('/login', request.url));
-  if (ISSUER_PUBLIC_PATHS.includes(pathname)) return NextResponse.next();
+  if (pathname === '/') {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  if (ISSUER_PUBLIC_PATHS.includes(pathname)) {
+    return NextResponse.next();
+  }
 
   const session = request.cookies.get('qrv_issuer_session')?.value;
-  if (!session || session !== '1') {
-    const loginUrl = new URL('/login', request.url);
-    loginUrl.searchParams.set('next', pathname);
-    return NextResponse.redirect(loginUrl);
   if (session === '1') {
     return NextResponse.next();
   }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "node server.js",
+    "start": "next start",
     "start:server": "node server.js",
-    "lint": "NODE_ENV=development next lint",
+    "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
### Motivation
- Consolidate public verification UI into a reusable `PublicVerifyLanding` component and ensure issuer users are redirected to `/login`.
- Make verification resolution robust to API URL/config changes and varying payload shapes from the verification service.
- Harden middleware routing for verify vs issuer roles by expanding allowed public paths and properly blocking issuer-only routes.

### Description
- Replace inline homepage markup with `PublicVerifyLanding` and switch to `isIssuerRole()` for the issuer redirect in `app/page.tsx`.
- Rework `lib/verification.ts` to use `QRV_API_BASE_URL` and `QRV_VERIFY_BASE_URL`, unify status handling as `VerificationStatus`, add `DEFAULTS` and `unavailableRecord()` helpers, normalize payload extraction (`payload.data`), and broaden field mappings and timestamp formatting; export `fetchVerification` as an alias for `resolveVerification`.
- Update `middleware.ts` to expand `VERIFY_PUBLIC_PATHS`, centralize internal-path detection in `isInternalPath()`, add blocking behavior for verify-role restricted prefixes, and simplify session/login redirect logic while preserving role checks.
- Update `package.json` scripts to use `next start` for `start` and `next lint` for `lint`.

### Testing
- No automated tests were executed as part of this change; run `npm run test`, `npm run lint`, and `npm run typecheck` in CI to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5dbce5b4832d8cebecd625e21e0d)