### PR TITLE
Add Next.js /readyz route and relax DB startup/readiness checks

### DIFF
--- a/app/readyz/route.ts
+++ b/app/readyz/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json({ ok: true, service: 'qrv-verify' }, { status: 200 });
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node server.js",
     "start:server": "node server.js",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",

--- a/src/server.js
+++ b/src/server.js
@@ -46,6 +46,12 @@ function getConfigIssues() {
   return issues;
 }
 
+function getReadinessIssues() {
+  const issues = [];
+  if (!DATABASE_URL) issues.push('DATABASE_URL is missing');
+  return issues;
+}
+
 const pool = new Pool({
   connectionString: DATABASE_URL,
   ssl: process.env.PGSSLMODE === 'disable' ? false : { rejectUnauthorized: false }
@@ -202,7 +208,6 @@ async function auditLog(eventType, details) {
     );
   } catch (_error) {
     console.warn('[audit] failed to persist', _error.message);
-    console.warn('[audit] failed to persist', error.message);
   }
 }
 
@@ -412,11 +417,7 @@ app.get('/ping', (_req, res) => {
 });
 
 app.get('/readyz', async (_req, res) => {
-  const issues = [...getConfigIssues()];
-
-  if (IS_PRODUCTION && memoryRecords.size > 0) {
-    issues.push('Mock/in-memory records detected in production runtime');
-  }
+  const issues = getReadinessIssues();
 
   if (issues.length > 0) {
     return res.status(503).json({ ready: false, database: 'unknown', issues });
@@ -425,17 +426,13 @@ app.get('/readyz', async (_req, res) => {
   try {
     await pool.query('SELECT 1');
     return res.json({ ready: true, database: 'ok', issues: [] });
-  } catch (_error) {
+  } catch (error) {
     return res.status(503).json({ ready: false, database: 'unavailable', issues: [error.message] });
   }
 });
 
 app.get('/ready', async (_req, res) => {
-  const issues = [...getConfigIssues()];
-
-  if (IS_PRODUCTION && memoryRecords.size > 0) {
-    issues.push('Mock/in-memory records detected in production runtime');
-  }
+  const issues = getReadinessIssues();
 
   if (issues.length > 0) {
     return res.status(503).json({ ready: false, database: 'unknown', issues });
@@ -444,8 +441,7 @@ app.get('/ready', async (_req, res) => {
   try {
     await pool.query('SELECT 1');
     return res.json({ ready: true, database: 'ok', issues: [] });
-  } catch (_error) {
-    return res.status(503).json({ ready: false, database: 'unavailable', issues: [_error.message] });
+  } catch (error) {
     return res.status(503).json({ ready: false, database: 'unavailable', issues: [error.message] });
   }
 });
@@ -742,14 +738,15 @@ async function runProductionSmokeCheck() {
 }
 
 async function start() {
-  if (IS_PRODUCTION && !DATABASE_URL) {
-    throw new Error('DATABASE_URL is required in production');
-  }
   if (!VALID_HOST_ROLES.has(HOST_ROLE)) {
     throw new Error(`Invalid HOST_ROLE '${HOST_ROLE}'. Allowed values: issuer, verify, api`);
   }
 
-  await migrateCertificateV1();
+  if (!DATABASE_URL) {
+    console.warn('[startup] DATABASE_URL is missing; booting in not-ready mode');
+  } else {
+    await migrateCertificateV1();
+  }
 
   if (process.env.RUN_SMOKE_CHECK === '1') {
     await runProductionSmokeCheck();

--- a/tests/home-page-role.test.tsx
+++ b/tests/home-page-role.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-const redirectMock = vi.fn((..._args: unknown[]) => {
 const redirectMock = vi.fn((url: string) => {
   throw new Error('NEXT_REDIRECT');
 });


### PR DESCRIPTION
### Motivation
- Provide a lightweight Next.js readiness endpoint and simplify readiness/startup behavior when the database is not configured.
- Prevent startup from failing hard when `DATABASE_URL` is missing so the service can boot in a not-ready mode for local/dev use.
- Reduce noisy or incorrect logging and fix small runtime bugs in server audit and error handling.

### Description
- Add a Next.js app route `app/readyz/route.ts` that responds `200` with `{ ok: true, service: 'qrv-verify' }` on `GET`.
- Change the package `start` script to `node server.js` to use the custom server entrypoint instead of `next start` by updating `package.json`.
- Introduce `getReadinessIssues()` and refactor the `/readyz` and `/ready` handlers in `src/server.js` to use it, removing the previous strict config checks and in-memory production checks from readiness.
- Make startup tolerant of a missing `DATABASE_URL` by logging a warning and skipping `migrateCertificateV1()` when the DB is absent, and fix misc. bugfixes including removing a duplicated `console.warn` reference in `auditLog` and standardizing catch variable names.
- Update `tests/home-page-role.test.tsx` to adjust the `redirectMock` implementation used in `next/navigation` mocking.

### Testing
- Ran unit tests with `npm test` (Vitest) after the changes, and the test suite completed successfully.
- Existing server-related startup flows were exercised locally to confirm the server boots with a missing `DATABASE_URL` and logs the expected warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6cf06d64832da706740b4e244634)