### PR TITLE
Add resilient acceptance:live runner with pacing, retries, and JSON output

### DIFF
--- a/artifacts/acceptance-live.json
+++ b/artifacts/acceptance-live.json
@@ -1,0 +1,81 @@
+{
+  "generatedAt": "2026-04-29T14:43:18.103Z",
+  "baseUrl": "https://verify.qrv.network",
+  "config": {
+    "baseDelayMs": 1500,
+    "jitterMs": {
+      "min": 1000,
+      "max": 2500
+    },
+    "retry429Max": 3,
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+  },
+  "summary": {
+    "totalNodes": 4,
+    "okNodes": 0,
+    "criticalFailures": 4,
+    "passed": false
+  },
+  "results": [
+    {
+      "path": "/",
+      "url": "https://verify.qrv.network/",
+      "status": null,
+      "ok": false,
+      "retriesUsed": 0,
+      "attempts": [
+        {
+          "attempt": 1,
+          "startedAt": "2026-04-29T14:43:08.711Z",
+          "error": "fetch failed"
+        }
+      ],
+      "critical": true
+    },
+    {
+      "path": "/verify/QRV-DEMO-001",
+      "url": "https://verify.qrv.network/verify/QRV-DEMO-001",
+      "status": null,
+      "ok": false,
+      "retriesUsed": 0,
+      "attempts": [
+        {
+          "attempt": 1,
+          "startedAt": "2026-04-29T14:43:12.782Z",
+          "error": "fetch failed"
+        }
+      ],
+      "critical": true
+    },
+    {
+      "path": "/help",
+      "url": "https://verify.qrv.network/help",
+      "status": null,
+      "ok": false,
+      "retriesUsed": 0,
+      "attempts": [
+        {
+          "attempt": 1,
+          "startedAt": "2026-04-29T14:43:15.416Z",
+          "error": "fetch failed"
+        }
+      ],
+      "critical": true
+    },
+    {
+      "path": "/scan",
+      "url": "https://verify.qrv.network/scan",
+      "status": null,
+      "ok": false,
+      "retriesUsed": 0,
+      "attempts": [
+        {
+          "attempt": 1,
+          "startedAt": "2026-04-29T14:43:18.039Z",
+          "error": "fetch failed"
+        }
+      ],
+      "critical": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "build": "echo \"no build step\"",
-    "dev": "node server.js"
+    "dev": "node server.js",
+    "acceptance:live": "node scripts/acceptance-live.mjs"
   },
   "dependencies": {
     "express": "^4.21.2"

--- a/scripts/acceptance-live.mjs
+++ b/scripts/acceptance-live.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+
+const BASE_URL = process.env.ACCEPTANCE_BASE_URL || 'https://verify.qrv.network';
+const RETRY_LIMIT = 3;
+const BASE_DELAY_MS = 1500;
+const JITTER_MIN_MS = 1000;
+const JITTER_MAX_MS = 2500;
+const OUTPUT_PATH = 'artifacts/acceptance-live.json';
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+const nodes = [
+  { path: '/', critical: true },
+  { path: '/verify/QRV-DEMO-001', critical: true },
+  { path: '/help', critical: true },
+  { path: '/scan', critical: true },
+];
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const jitterMs = () => Math.floor(Math.random() * (JITTER_MAX_MS - JITTER_MIN_MS + 1)) + JITTER_MIN_MS;
+
+function parseRetryAfterMs(value) {
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, Math.round(seconds * 1000));
+  }
+
+  const retryDate = Date.parse(value);
+  if (Number.isNaN(retryDate)) return 0;
+  return Math.max(0, retryDate - Date.now());
+}
+
+async function requestNode(path) {
+  const url = `${BASE_URL}${path}`;
+  const attempts = [];
+
+  for (let attempt = 1; attempt <= RETRY_LIMIT + 1; attempt += 1) {
+    const startedAt = new Date().toISOString();
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'User-Agent': USER_AGENT,
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+      });
+      const retryAfterHeader = response.headers.get('retry-after');
+      const status = response.status;
+
+      attempts.push({
+        attempt,
+        startedAt,
+        status,
+        ok: response.ok,
+        retryAfter: retryAfterHeader,
+      });
+
+      if (status !== 429 || attempt > RETRY_LIMIT) {
+        return {
+          path,
+          url,
+          status,
+          ok: response.ok,
+          retriesUsed: attempt - 1,
+          attempts,
+        };
+      }
+
+      const retryAfterMs = parseRetryAfterMs(retryAfterHeader);
+      const waitMs = retryAfterMs > 0 ? retryAfterMs : BASE_DELAY_MS + jitterMs();
+      await sleep(waitMs);
+    } catch (error) {
+      attempts.push({
+        attempt,
+        startedAt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      return {
+        path,
+        url,
+        status: null,
+        ok: false,
+        retriesUsed: attempt - 1,
+        attempts,
+      };
+    }
+  }
+
+  return {
+    path,
+    url,
+    status: null,
+    ok: false,
+    retriesUsed: RETRY_LIMIT,
+    attempts,
+  };
+}
+
+async function main() {
+  const results = [];
+
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+    if (index > 0) {
+      await sleep(BASE_DELAY_MS + jitterMs());
+    }
+
+    const result = await requestNode(node.path);
+    results.push({ ...result, critical: node.critical });
+  }
+
+  const criticalFailures = results.filter((result) => result.critical && !result.ok);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    baseUrl: BASE_URL,
+    config: {
+      baseDelayMs: BASE_DELAY_MS,
+      jitterMs: { min: JITTER_MIN_MS, max: JITTER_MAX_MS },
+      retry429Max: RETRY_LIMIT,
+      userAgent: USER_AGENT,
+    },
+    summary: {
+      totalNodes: results.length,
+      okNodes: results.filter((r) => r.ok).length,
+      criticalFailures: criticalFailures.length,
+      passed: criticalFailures.length === 0,
+    },
+    results,
+  };
+
+  await mkdir('artifacts', { recursive: true });
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  console.log(`Wrote ${OUTPUT_PATH}`);
+
+  if (criticalFailures.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Improve the existing live acceptance probe to be resilient to rate-limiting and produce machine-readable output for CI/ops.
- Ensure probes behave like a browser by sending a `User-Agent`, pace requests to avoid spikes, and respect server-suggested backoff with `Retry-After`.
- Make CI detect failures by returning a non-zero exit code when critical endpoints fail.

### Description
- Add a new runner `scripts/acceptance-live.mjs` that checks configured nodes and writes a structured report to `artifacts/acceptance-live.json`.
- Implement pacing with a fixed `1500ms` base delay plus random jitter between `1000–2500ms` between requests and retries.
- Add retry logic for `429` responses up to `3` retries and support `Retry-After` values expressed as seconds or HTTP date strings via `parseRetryAfterMs`.
- Configure a browser-like `User-Agent`, record per-attempt metadata (`attempt`, `startedAt`, `status`, `retryAfter`, or `error`), add `acceptance:live` npm script in `package.json`, and set a non-zero exit code when any critical node fails.

### Testing
- Ran `npm run acceptance:live` which executed the new runner and produced `artifacts/acceptance-live.json` successfully.
- Verified the report contains `config`, `summary`, and per-node `results` with attempts information and timestamps.
- Observed the process exit non-zero in this environment when critical nodes failed due to unreachable / rate-limited responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21878de48832da42016d5832705cb)