### PR TITLE
Add /health, /ping, and enriched /version endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -247,16 +247,33 @@ app.get('/settings', (_req, res) => {
   res.type('html').send(shellLayout({ title: 'Settings', active: 'settings', body }));
 });
 
+function serviceStatusResponse() {
+  return {
+    status: 'ok',
+    service: 'qrv-api',
+    version: VERSION,
+    timestamp: new Date().toISOString()
+  };
+}
+
+app.get('/health', (_req, res) => {
+  res.status(200).json(serviceStatusResponse());
+});
+
+app.get('/ping', (_req, res) => {
+  res.status(200).json(serviceStatusResponse());
+});
+
+app.get('/version', (_req, res) => {
+  res.status(200).json(serviceStatusResponse());
+});
+
 app.get('/healthz', (_req, res) => {
   res.status(200).json({ status: 'ok' });
 });
 
 app.get('/readyz', (_req, res) => {
   res.status(200).json({ status: 'ready' });
-});
-
-app.get('/version', (_req, res) => {
-  res.status(200).json({ version: VERSION });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
### Motivation
- Provide simple, consistent service status endpoints for health checks and monitoring.
- Standardize the status payload to include `status`, `service`, `version`, and an ISO8601 `timestamp` for consumers.

### Description
- Added a shared `serviceStatusResponse()` helper that builds the status payload using `VERSION` and the current time.
- Implemented `GET /health` and `GET /ping` to return the full service status payload.
- Updated `GET /version` to return the same enriched status payload for consistency.
- Left existing compatibility endpoints `GET /healthz` and `GET /readyz` unchanged.

### Testing
- Ran `node --check server.js` to validate syntax, which succeeded.
- Started the server and exercised `curl` against `GET /health`, `GET /ping`, and `GET /version`, and each returned the expected JSON containing `status: "ok"`, `service: "qrv-api"`, `version` and an ISO8601 `timestamp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f218947020832d94952740bf9dd2f6)