### PR TITLE
Add first production-safe demo record (QRV-PROD-CERT-000001)

### DIFF
--- a/qrv-demo-records/QRV-PROD-CERT-000001.json
+++ b/qrv-demo-records/QRV-PROD-CERT-000001.json
@@ -1,0 +1,10 @@
+{
+  "qrvid": "QRV-PROD-CERT-000001",
+  "status": "VERIFIED",
+  "issuer": "QR-V Network",
+  "type": "Certificate",
+  "holder": "Demo Public Record",
+  "created_at": "2026-04-29T14:43:43Z",
+  "hash": "92b6224ab17b60740bc9e5e5cfebb69e061200d1d09c15c86d3203204fa43831",
+  "signature": "808e1d56f3bc2e4b93d5f0e8c463afbc8862ebbc0d0ad10a844fc5f9c5e8a5bf"
+}


### PR DESCRIPTION
### Motivation
- Seed the repository with the permanent production demo record `QRV-PROD-CERT-000001` so public verification URLs and smoke checks resolve to a known `VERIFIED` test certificate.

### Description
- Add `qrv-demo-records/QRV-PROD-CERT-000001.json` containing `qrvid` `QRV-PROD-CERT-000001` and the fields `status: VERIFIED`, `issuer: QR-V Network`, `type: Certificate`, `holder: Demo Public Record`, `created_at` (UTC timestamp), `hash` (SHA-256 of the canonical payload string), and `signature` (HMAC-SHA256 over the hash using demo key `QRV-PROD-DEMO-SIGNING-KEY`).

### Testing
- Ran `cat qrv-demo-records/QRV-PROD-CERT-000001.json`, `git status --short`, `git add qrv-demo-records/QRV-PROD-CERT-000001.json && git commit -m "Add first production-safe demo record"`, and `nl -ba qrv-demo-records/QRV-PROD-CERT-000001.json`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2189f3c40832db6e346e24717ca0a)