### PR TITLE
Upgrade PostgreSQL schema for registry domain tables

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,30 +1,110 @@
-CREATE SEQUENCE IF NOT EXISTS registry_qrvid_seq START WITH 1 INCREMENT BY 1;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-CREATE TABLE IF NOT EXISTS registry_records (
-  qrvid text PRIMARY KEY,
+-- Core entities
+CREATE TABLE IF NOT EXISTS issuers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  issuer_code text NOT NULL UNIQUE,
+  legal_name text NOT NULL,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'inactive')),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  deleted_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  qrvid text NOT NULL UNIQUE,
+  issuer_id uuid NOT NULL REFERENCES issuers(id) ON DELETE RESTRICT,
   title text NOT NULL,
   subject text NOT NULL,
-  issuer text NOT NULL,
-  status text NOT NULL DEFAULT 'active',
-  revoked_at timestamptz,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked', 'expired')),
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  issued_at timestamptz NOT NULL DEFAULT NOW(),
+  expires_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT NOW(),
-  certificate_version integer NOT NULL DEFAULT 1
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  deleted_at timestamptz,
+  CONSTRAINT records_expiry_after_issue CHECK (expires_at IS NULL OR expires_at > issued_at)
 );
 
-CREATE TABLE IF NOT EXISTS registry_audit_log (
+CREATE TABLE IF NOT EXISTS revocations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  record_id uuid NOT NULL REFERENCES records(id) ON DELETE CASCADE,
+  issuer_id uuid NOT NULL REFERENCES issuers(id) ON DELETE RESTRICT,
+  reason text NOT NULL,
+  revoked_at timestamptz NOT NULL DEFAULT NOW(),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  deleted_at timestamptz,
+  CONSTRAINT revocations_record_unique UNIQUE (record_id)
+);
+
+CREATE TABLE IF NOT EXISTS audit_logs (
   id bigserial PRIMARY KEY,
+  issuer_id uuid REFERENCES issuers(id) ON DELETE SET NULL,
+  record_id uuid REFERENCES records(id) ON DELETE SET NULL,
+  actor text NOT NULL,
   event_type text NOT NULL,
-  details jsonb NOT NULL,
-  created_at timestamptz NOT NULL DEFAULT NOW()
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at timestamptz NOT NULL DEFAULT NOW(),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  deleted_at timestamptz
 );
 
-INSERT INTO registry_records (qrvid, title, subject, issuer, status, certificate_version)
-VALUES (
-  'QRV-PROD-CERT-000001',
-  'QR-V Production Seed Certificate',
-  'QR-V Production Test Subject',
-  'QR-V Production Issuer',
-  'active',
-  1
-)
-ON CONFLICT (qrvid) DO NOTHING;
+CREATE TABLE IF NOT EXISTS api_keys (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  issuer_id uuid NOT NULL REFERENCES issuers(id) ON DELETE CASCADE,
+  key_hash text NOT NULL UNIQUE,
+  label text NOT NULL,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked')),
+  last_used_at timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  deleted_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS billing_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  issuer_id uuid NOT NULL UNIQUE REFERENCES issuers(id) ON DELETE CASCADE,
+  external_customer_id text UNIQUE,
+  plan text NOT NULL DEFAULT 'free',
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'past_due', 'canceled')),
+  current_period_start timestamptz,
+  current_period_end timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  deleted_at timestamptz,
+  CONSTRAINT billing_period_valid CHECK (
+    current_period_end IS NULL
+    OR current_period_start IS NULL
+    OR current_period_end > current_period_start
+  )
+);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id bigserial PRIMARY KEY,
+  issuer_id uuid NOT NULL REFERENCES issuers(id) ON DELETE CASCADE,
+  record_id uuid REFERENCES records(id) ON DELETE SET NULL,
+  event_type text NOT NULL,
+  quantity integer NOT NULL DEFAULT 1 CHECK (quantity > 0),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  event_at timestamptz NOT NULL DEFAULT NOW(),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  deleted_at timestamptz
+);
+
+-- Performance indexes (including soft-delete aware partial indexes)
+CREATE INDEX IF NOT EXISTS idx_issuers_active ON issuers (status) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_records_issuer_active ON records (issuer_id, status) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_records_qrvid_active ON records (qrvid) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_revocations_issuer_active ON revocations (issuer_id, revoked_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_audit_logs_issuer_time ON audit_logs (issuer_id, occurred_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_audit_logs_record_time ON audit_logs (record_id, occurred_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_api_keys_issuer_status ON api_keys (issuer_id, status) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_billing_accounts_status ON billing_accounts (status) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_issuer_event_at ON usage_events (issuer_id, event_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_type_event_at ON usage_events (event_type, event_at DESC) WHERE deleted_at IS NULL;


### PR DESCRIPTION
### Motivation
- Provide a full domain schema for the registry with proper relations, constraints, lifecycle fields and indexes to support production usage and soft-delete semantics.

### Description
- Enable `pgcrypto` and add core tables: `issuers`, `records`, `revocations`, `audit_logs`, `api_keys`, `billing_accounts`, and `usage_events` with UUID primary keys and appropriate foreign keys.
- Add lifecycle timestamp fields (`created_at`, `updated_at`) and soft-delete support via `deleted_at` on all tables and a `issued_at`/`expires_at` pair on `records` with an expiry check constraint.
- Add data integrity constraints including uniqueness, status value checks, `records_expiry_after_issue` and `billing_period_valid`, positive `quantity` check, and one-revocation-per-record uniqueness.
- Add performance-focused indexes including partial indexes scoped to non-deleted rows (`WHERE deleted_at IS NULL`) to support soft-delete-aware queries.

### Testing
- Automated inspection of the updated `db/schema.sql` completed and confirmed the new tables, constraints and indexes are present in the file.
- Automated VCS step to record the change completed without errors and the working tree reflects the updated `db/schema.sql`.
- No database migrations or CI test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22f67873c832d8f446b4bef5f7c8d)