### PR TITLE
Enforce QR-V domain ownership and add domain content-type smoke tests

### DIFF
--- a/docs/production-domain-map.md
+++ b/docs/production-domain-map.md
@@ -1,0 +1,16 @@
+# Production Domain Ownership Map
+
+This map is the source of truth for QR-V production domain boundaries.
+
+| Domain | Ownership | Allowed surface | Blocked surface |
+| --- | --- | --- | --- |
+| `api.qrv.network` | Backend API service | Backend/status endpoints only (for example `/healthz`, `/readyz`, `/version`) returning JSON | Any issuer or verification HTML UI routes |
+| `issuer.qrv.network` | Issuer application | Issuer UI only (login/dashboard issuer workflows) | Verification-only UI routes and backend-only domains |
+| `verify.qrv.network` | Verification application | Verification UI only (`/`, `/scan`, `/help`, `/verify/:id`) | Issuer-only routes |
+| `registry.qrv.network` | Registry/status backend | Registry/status endpoints only (JSON status + registry backend APIs) | Any issuer or verification HTML UI routes |
+
+## Enforcement in this repository
+
+- Domain ownership is enforced in `middleware.ts` using host-based allowlists.
+- Backend-only hosts return a JSON 404 payload for any non-status route.
+- Unknown hosts return JSON 404 payloads to avoid cross-domain UI leakage.

--- a/docs/smoke-tests.md
+++ b/docs/smoke-tests.md
@@ -2,6 +2,15 @@
 
 > Replace `BASE_URL` with the deployed host and `ISSUER_TOKEN` with a valid issuer credential.
 
+## 0) Domain ownership/content-type smoke test
+```bash
+npm run smoke:domains
+```
+
+Expected:
+- `api.qrv.network` and `registry.qrv.network` respond with `Content-Type: application/json...`
+- `issuer.qrv.network` and `verify.qrv.network` respond with `Content-Type: text/html...`
+
 ## 1) Health
 ```bash
 curl -sS "$BASE_URL/health"

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getAppRole } from '@/lib/app-role';
 
 const ISSUER_PUBLIC_PATHS = ['/login', '/healthz', '/readyz', '/version'];
 const VERIFY_PUBLIC_PATHS = ['/', '/scan', '/help', '/api-status', '/healthz', '/readyz', '/version'];
@@ -12,6 +11,10 @@ const VERIFY_BLOCKED_PREFIXES = [
   '/analytics',
   '/revocations',
 ];
+
+const ISSUER_HOSTS = new Set(['issuer.qrv.network']);
+const VERIFY_HOSTS = new Set(['verify.qrv.network']);
+const BACKEND_ONLY_HOSTS = new Set(['api.qrv.network', 'registry.qrv.network']);
 
 function isInternalPath(pathname: string): boolean {
   return pathname.startsWith('/_next') || pathname.startsWith('/api') || pathname.startsWith('/favicon') || pathname.includes('.');
@@ -30,6 +33,14 @@ function isBlockedVerifyPath(pathname: string): boolean {
   return VERIFY_BLOCKED_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
+function getHost(request: NextRequest): string {
+  return request.headers.get('x-forwarded-host')?.split(',')[0]?.trim().toLowerCase() ?? request.nextUrl.hostname.toLowerCase();
+}
+
+function isBackendStatusPath(pathname: string): boolean {
+  return pathname === '/healthz' || pathname === '/readyz' || pathname === '/version';
+}
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -37,9 +48,23 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const appRole = getAppRole();
+  const host = getHost(request);
 
-  if (appRole === 'verify') {
+  if (BACKEND_ONLY_HOSTS.has(host)) {
+    if (isBackendStatusPath(pathname)) {
+      return NextResponse.next();
+    }
+
+    return NextResponse.json(
+      {
+        error: 'Not Found',
+        message: `${host} is a backend-only domain.`,
+      },
+      { status: 404 },
+    );
+  }
+
+  if (VERIFY_HOSTS.has(host)) {
     if (VERIFY_PUBLIC_PATHS.includes(pathname) || isVerifyRecordPath(pathname)) {
       return NextResponse.next();
     }
@@ -51,22 +76,32 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  if (pathname === '/') {
-    return NextResponse.redirect(new URL('/login', request.url));
+  if (ISSUER_HOSTS.has(host)) {
+    if (pathname === '/') {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+
+    if (ISSUER_PUBLIC_PATHS.includes(pathname)) {
+      return NextResponse.next();
+    }
+
+    const session = request.cookies.get('qrv_issuer_session')?.value;
+    if (session === '1') {
+      return NextResponse.next();
+    }
+
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('next', pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
-  if (ISSUER_PUBLIC_PATHS.includes(pathname)) {
-    return NextResponse.next();
-  }
-
-  const session = request.cookies.get('qrv_issuer_session')?.value;
-  if (session === '1') {
-    return NextResponse.next();
-  }
-
-  const loginUrl = new URL('/login', request.url);
-  loginUrl.searchParams.set('next', pathname);
-  return NextResponse.redirect(loginUrl);
+  return NextResponse.json(
+    {
+      error: 'Not Found',
+      message: `Unrecognized host ${host}.`,
+    },
+    { status: 404 },
+  );
 }
 
 export const config = {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "check": "node --check server.js",
     "build": "next build",
     "dev": "next dev",
-    "acceptance:live": "node scripts/acceptance-live.mjs"
+    "acceptance:live": "node scripts/acceptance-live.mjs",
+    "smoke:domains": "node scripts/smoke-domain-content-type.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/scripts/smoke-domain-content-type.mjs
+++ b/scripts/smoke-domain-content-type.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const checks = [
+  {
+    name: 'api backend root is not HTML UI',
+    url: process.env.API_QRV_URL || 'https://api.qrv.network/',
+    expectContentTypePrefix: 'application/json',
+  },
+  {
+    name: 'issuer root serves issuer UI HTML',
+    url: process.env.ISSUER_QRV_URL || 'https://issuer.qrv.network/',
+    expectContentTypePrefix: 'text/html',
+  },
+  {
+    name: 'verify root serves verify UI HTML',
+    url: process.env.VERIFY_QRV_URL || 'https://verify.qrv.network/',
+    expectContentTypePrefix: 'text/html',
+  },
+  {
+    name: 'registry backend root is not HTML UI',
+    url: process.env.REGISTRY_QRV_URL || 'https://registry.qrv.network/',
+    expectContentTypePrefix: 'application/json',
+  },
+];
+
+async function runCheck(check) {
+  const response = await fetch(check.url, { method: 'GET', redirect: 'manual' });
+  const contentType = response.headers.get('content-type') || '';
+  const passed = contentType.toLowerCase().startsWith(check.expectContentTypePrefix);
+
+  return {
+    ...check,
+    status: response.status,
+    contentType,
+    passed,
+  };
+}
+
+async function main() {
+  const results = [];
+
+  for (const check of checks) {
+    try {
+      results.push(await runCheck(check));
+    } catch (error) {
+      results.push({
+        ...check,
+        passed: false,
+        status: null,
+        contentType: '',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  let failures = 0;
+  for (const result of results) {
+    if (result.passed) {
+      console.log(`PASS ${result.name}: ${result.status} ${result.contentType}`);
+      continue;
+    }
+
+    failures += 1;
+    console.error(
+      `FAIL ${result.name}: status=${result.status} content-type="${result.contentType}" expected-prefix="${result.expectContentTypePrefix}"${
+        result.error ? ` error=${result.error}` : ''
+      }`,
+    );
+  }
+
+  if (failures > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Prevent cross-domain UI leakage and ensure each production domain only serves its intended surface (issuer UI, verify UI, or backend APIs). 
- Make domain responsibilities explicit in repository documentation to serve as an operational source-of-truth. 
- Add automated smoke checks to quickly validate that deployed domains return the expected `Content-Type` for UI vs backend surfaces. 

### Description
- Enforce host-based domain ownership in `middleware.ts` with allowlists for `issuer.qrv.network`, `verify.qrv.network`, and backend-only hosts `api.qrv.network` and `registry.qrv.network`. 
- Backend-only hosts only allow status endpoints (`/healthz`, `/readyz`, `/version`) and return a JSON 404 for any other path, while unknown hosts return a JSON 404 to avoid UI leakage. 
- Add `docs/production-domain-map.md` as the production domain ownership map describing allowed and blocked surfaces. 
- Add `scripts/smoke-domain-content-type.mjs` and `npm run smoke:domains` to validate domain `Content-Type` expectations and update `docs/smoke-tests.md` to include the new check. 

### Testing
- Ran `npm run check` which passed (syntax check of `server.js`). 
- Ran `npm run smoke:domains` in this environment which executed but failed due to outbound fetch/DNS/network resolution errors (each check returned `fetch failed`), so remote validations could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f353cb64e4832d89d67d31c9d57e80)