### PR TITLE
Upgrade qrv.network marketing root site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,35 +1,42 @@
-# Required production env vars
-DATABASE_URL=postgres://user:password@host:5432/database
-SIGNING_SECRET=replace-with-long-random-secret
-ISSUER_TOKEN=replace-with-issuer-bearer-token
-JWT_SECRET=replace-with-jwt-secret
-ADMIN_TOKEN=replace-with-admin-bearer-token
+# QR-V Network production root site configuration
+NODE_ENV=production
+PORT=3000
+APP_VERSION=1.2.0
 
-# Public base URLs
-APP_BASE_URL=https://issuer.qrv.network
+# Hostinger / public root site
+APP_BASE_URL=https://qrv.network
+QRV_PUBLIC_SITE_URL=https://qrv.network
+
+# Public QR-V Network URLs used by route pages and Live Network cards
+QRV_VERIFY_URL=https://verify.qrv.network
+QRV_REGISTRY_URL=https://registry.qrv.network
+QRV_API_URL=https://api.qrv.network
+QRV_ISSUER_URL=https://issuer.qrv.network
+QRV_DOCS_URL=https://docs.qrv.network
+QRV_DEVELOPERS_URL=https://developers.qrv.network
+QRV_STATUS_URL=https://status.qrv.network
+
+# Compatibility aliases for existing QR-V services and legacy scripts
 VERIFY_BASE_URL=https://verify.qrv.network
+REGISTRY_BASE_URL=https://registry.qrv.network
 NEXT_PUBLIC_QRV_API_BASE_URL=https://api.qrv.network
 NEXT_PUBLIC_QRV_VERIFY_BASE_URL=https://verify.qrv.network
 NEXT_PUBLIC_QRV_REGISTRY_BASE_URL=https://registry.qrv.network
-CORS_ALLOWED_ORIGINS=https://issuer.qrv.network,https://verify.qrv.network,https://qrv.network
-
-# Optional compatibility aliases (prefer canonical names above)
-# ADMIN_API_KEY=
-# ISSUER_API_KEY_SECRET=
-# ISSUER_JWT_SECRET=
-# QRV_SIGNING_SECRET=
-
-# Runtime tuning (optional)
-NODE_ENV=production
-PORT=3000
-HOST_ROLE=verify
-RATE_LIMIT_WINDOW_MS=60000
-RATE_LIMIT_MAX=100
-PGSSLMODE=require
 NEXT_PUBLIC_QRV_API_BASE=https://api.qrv.network
-NEXT_PUBLIC_APP_ROLE=verify
+NEXT_PUBLIC_APP_ROLE=marketing
+HOST_ROLE=marketing
 
-# Stripe billing
+# Optional issuer/registry write credentials for compatibility issuer routes only
+ISSUER_API_KEY=
+REGISTRY_API_KEY=
+DEFAULT_ISSUER_NAME=QR-V Demo Issuer
+
+# Runtime tuning
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX=180
+CORS_ALLOWED_ORIGINS=https://qrv.network,https://verify.qrv.network,https://registry.qrv.network,https://api.qrv.network,https://issuer.qrv.network,https://docs.qrv.network,https://developers.qrv.network,https://status.qrv.network
+
+# Optional billing placeholders retained for issuer/payment integrations
 STRIPE_SECRET_KEY=sk_live_replace_me
 STRIPE_WEBHOOK_SECRET=whsec_replace_me
 STRIPE_PRICE_STARTER=price_replace_starter_99

--- a/README.md
+++ b/README.md
@@ -1,64 +1,143 @@
-# qrv-platform (Express multi-domain production service)
+# QR-V Network root site (`qrv.network`)
 
-Single Express service that can run domain-specific behaviors for:
+This repository now runs the production root marketing site for **qrv.network** as a Hostinger-compatible Node/Express application.
 
-- `api.qrv.network` (API-only root)
-- `issuer.qrv.network` (issuer portal MVP)
-- `verify.qrv.network` (public verification)
-- `registry.qrv.network` (live registry records)
-- `qrv.network` (public demo flow)
+## Hostinger compatibility
 
-## Production highlights
+Use these settings in Hostinger's Node.js app configuration:
 
-- `api.qrv.network` root returns JSON only:
-  - `service`
-  - `version`
-  - `docs`
-  - `status`
-- Issuer portal MVP on `issuer.qrv.network`:
-  - `/login`
-  - `/dashboard`
-  - `/records/create`
-  - `/records/revoke`
-  - `/analytics/scan`
-- Verify routes read live registry records (`/api/v1/registry/:qrvid` or configured `REGISTRY_BASE_URL`).
-- Seeded production demo QRVID: `QRV-DEMO-0001`.
-- Public demo flow: `/demo` -> scan `QRV-DEMO-0001` -> `VERIFIED`.
-- Uptime monitor endpoint checks verify/registry/api/issuer dependencies: `/api/v1/uptime`.
+- **Node version:** `20.x`
+- **Application root:** `./`
+- **Entry file:** `server.js`
+- **Start command:** `npm start`
+- **Install command:** `npm install`
 
-## Routes
+The app intentionally uses a single `server.js` entry point and does not require a separate build step.
+
+## Public site routes
+
+The root site serves real route-specific pages for:
 
 - `/`
-- `/demo`
+- `/protocol`
+- `/how-it-works`
+- `/registry`
+- `/use-cases`
+- `/use-cases/certificates`
+- `/use-cases/membership-id`
+- `/use-cases/product-authentication`
+- `/use-cases/document-verification`
+- `/use-cases/asset-records`
+- `/developers`
+- `/pricing`
+- `/book-demo`
+- `/about`
+- `/status`
+- `/security`
+- `/legal`
+- `/privacy`
+- `/terms`
+
+The first product positioning is **QR-V Verified Certificates**. Pricing content includes:
+
+- Starter Issuer
+- Growth Issuer
+- Professional Issuer
+- Enterprise / Network Issuer
+- Launch Packages
+
+## Global QRVID verification redirect
+
+Every page includes a global QRVID verification form. Submitting a QRVID redirects with HTTP `303` to:
+
+```text
+https://verify.qrv.network/{QRVID}
+```
+
+The local compatibility route also supports:
+
+```text
+GET /verify?qrvid={QRVID}
+POST /verify
+```
+
+## Live Network URLs
+
+Set the public URLs in `.env` using the values from `.env.example`:
+
+- `QRV_PUBLIC_SITE_URL=https://qrv.network`
+- `QRV_VERIFY_URL=https://verify.qrv.network`
+- `QRV_REGISTRY_URL=https://registry.qrv.network`
+- `QRV_API_URL=https://api.qrv.network`
+- `QRV_ISSUER_URL=https://issuer.qrv.network`
+- `QRV_DOCS_URL=https://docs.qrv.network`
+- `QRV_DEVELOPERS_URL=https://developers.qrv.network`
+- `QRV_STATUS_URL=https://status.qrv.network`
+
+These values power the **Live Network** cards for:
+
+- `qrv.network`
+- `verify.qrv.network`
+- `registry.qrv.network`
+- `api.qrv.network`
+- `issuer.qrv.network`
+- `docs.qrv.network`
+- `developers.qrv.network`
+- `status.qrv.network`
+
+## Health and runtime endpoints
+
+Hostinger, uptime monitors, and load balancers can use:
+
+- `/health`
 - `/healthz`
+- `/ready`
 - `/readyz`
 - `/version`
-- `/api/v1/uptime`
-- `/api/v1/registry/:qrvid`
-- `/api/v1/registry`
-- `/api/v1/registry/:qrvid/revoke`
-- `/api/v1/verify/:qrvid`
-- `/verify/:qrvid`
-- `/:qrvid`
+- `/ping`
 
-## Scripts
-
-- `npm run start` → `node server.js`
-- `npm run build` → `echo "no build step"`
-- `npm run dev` → `node server.js`
-
-## Deploy (Hostinger)
-
-Use the **Express** preset.
-
-- Build command: `npm run build`
-- Start command: `npm run start`
-
-## Local run
+## Local development
 
 ```bash
 npm install
-npm run dev
+npm run check
+npm start
 ```
 
-- Go-live execution plan: `docs/qrv-go-live-build-plan.md`
+Then open `http://localhost:3000`.
+
+For a different local port:
+
+```bash
+PORT=3010 npm start
+```
+
+## Hostinger deployment steps
+
+1. Upload or deploy the repository contents to the Hostinger Node.js application root.
+2. Confirm the application root is `./` and the startup file is `server.js`.
+3. Select Node `20.x`.
+4. Add environment variables from `.env.example` in Hostinger's environment variable panel.
+5. Run `npm install` from Hostinger or allow Hostinger to install dependencies.
+6. Start the app with `npm start`.
+7. Verify the deployment:
+   - `https://qrv.network/health`
+   - `https://qrv.network/ready`
+   - `https://qrv.network/version`
+   - `https://qrv.network/pricing`
+   - Submit a QRVID and confirm it redirects to `https://verify.qrv.network/{QRVID}`.
+
+## Compatibility notes
+
+The app keeps lightweight issuer compatibility endpoints for existing operational tooling:
+
+- `GET /issue`
+- `POST /issue`
+- `POST /api/issue`
+- `POST /api/revoke/:qrvid`
+
+These routes require registry credentials when creating or revoking live records. The public qrv.network root site does not require registry credentials to render marketing pages or health endpoints.
+
+## Trust and legal disclaimer
+
+QR-V provides registry-backed verification infrastructure and public status pages. QR-V does not automatically certify the truth, legality, ownership, identity, regulatory standing, or fitness of issuer-supplied content. Issuers remain responsible for their claims, and relying parties should review issuer identity, record scope, jurisdiction, applicable law, and current verification status before making decisions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "qrv-verify",
-  "version": "1.0.0",
+  "name": "qrv-marketing-site",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "qrv-verify",
-      "version": "1.0.0",
+      "name": "qrv-marketing-site",
+      "version": "1.2.0",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -14,28 +14,10 @@
         "express-rate-limit": "^7.5.1",
         "helmet": "^8.1.0",
         "joi": "^17.13.3",
-        "next": "^16.0.0",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
         "stripe": "^18.0.0"
       },
-      "devDependencies": {
-        "@types/react": "19.2.14",
-        "typescript": "6.0.3"
-      },
       "engines": {
-        "node": "20.x",
-        "npm": "10.x"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
+        "node": "20.x"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -51,606 +33,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
-      "license": "MIT"
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@sideway/address": {
@@ -674,15 +56,6 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -692,16 +65,6 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/accepts": {
@@ -722,18 +85,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.24",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/body-parser": {
       "version": "1.20.5",
@@ -839,32 +190,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -918,13 +243,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -942,16 +260,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -1381,24 +689,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1406,59 +696,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@next/env": "16.2.4",
-        "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.9.19",
-        "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
-        "styled-jsx": "5.1.6"
-      },
-      "bin": {
-        "next": "dist/bin/next"
-      },
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
-        "sharp": "^0.34.5"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.51.1",
-        "babel-plugin-react-compiler": "*",
-        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "sass": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@playwright/test": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
       }
     },
     "node_modules/object-assign": {
@@ -1508,40 +745,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
-    },
-    "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1607,27 +810,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.5"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1653,25 +835,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -1732,51 +895,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
-    },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1850,15 +968,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1888,29 +997,6 @@
         }
       }
     },
-    "node_modules/styled-jsx": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
-      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
-      "license": "MIT",
-      "dependencies": {
-        "client-only": "0.0.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1919,12 +1005,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1937,20 +1017,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "issuer-qrv",
-  "version": "1.1.0",
+  "name": "qrv-marketing-site",
+  "version": "1.2.0",
   "private": true,
-  "description": "QR-V issuer portal and certificate issuance control plane.",
+  "description": "Production qrv.network root marketing site with QRVID verification routing.",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
@@ -22,6 +22,6 @@
     "stripe": "^18.0.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": "20.x"
   }
 }

--- a/server.js
+++ b/server.js
@@ -6,32 +6,189 @@ const rateLimit = require('express-rate-limit');
 
 const app = express();
 const isProduction = process.env.NODE_ENV === 'production';
-const PORT = Number(process.env.PORT || 3001);
-const VERSION = process.env.APP_VERSION || process.env.npm_package_version || '1.1.0';
-const APP_BASE_URL = process.env.APP_BASE_URL || 'https://issuer.qrv.network';
-const REGISTRY_BASE_URL = process.env.REGISTRY_BASE_URL || 'https://registry.qrv.network';
-const VERIFY_BASE_URL = process.env.VERIFY_BASE_URL || 'https://verify.qrv.network';
+const PORT = Number(process.env.PORT || 3000);
+const VERSION = process.env.APP_VERSION || process.env.npm_package_version || '1.2.0';
+
+const URLS = {
+  site: publicUrl(process.env.QRV_PUBLIC_SITE_URL || process.env.APP_BASE_URL, 'https://qrv.network'),
+  verify: publicUrl(process.env.QRV_VERIFY_URL || process.env.VERIFY_BASE_URL, 'https://verify.qrv.network'),
+  registry: publicUrl(process.env.QRV_REGISTRY_URL || process.env.REGISTRY_BASE_URL, 'https://registry.qrv.network'),
+  api: publicUrl(process.env.QRV_API_URL || process.env.NEXT_PUBLIC_QRV_API_BASE_URL, 'https://api.qrv.network'),
+  issuer: publicUrl(process.env.QRV_ISSUER_URL, 'https://issuer.qrv.network'),
+  docs: publicUrl(process.env.QRV_DOCS_URL, 'https://docs.qrv.network'),
+  developers: publicUrl(process.env.QRV_DEVELOPERS_URL, 'https://developers.qrv.network'),
+  status: publicUrl(process.env.QRV_STATUS_URL, 'https://status.qrv.network')
+};
+
 const ISSUER_API_KEY = process.env.ISSUER_API_KEY || process.env.REGISTRY_API_KEY || '';
-const DEFAULT_ISSUER_NAME = process.env.DEFAULT_ISSUER_NAME || 'QRV Demo Issuer';
-const DEFAULT_RECORD_PREFIX = process.env.DEFAULT_RECORD_PREFIX || 'QRV-CERT';
+const DEFAULT_ISSUER_NAME = process.env.DEFAULT_ISSUER_NAME || 'QR-V Demo Issuer';
 
 app.disable('x-powered-by');
-app.use(helmet());
-app.use(cors());
+app.set('trust proxy', 1);
+app.use(helmet({ contentSecurityPolicy: false }));
+app.use(cors({ origin: true, credentials: false }));
 app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true }));
-app.use(rateLimit({ windowMs: 60 * 1000, max: 120 }));
+app.use(rateLimit({ windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000), max: Number(process.env.RATE_LIMIT_MAX || 180) }));
 
 function now() { return new Date().toISOString(); }
 function escapeHtml(value) { return String(value ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
 function authHeaders() { return ISSUER_API_KEY ? { authorization: `Bearer ${ISSUER_API_KEY}` } : {}; }
+function publicUrl(value, fallback) { return String(value || fallback).replace(/\/+$/, ''); }
+function cleanQrvid(value) { return String(value || '').trim().replace(/^https?:\/\/verify\.qrv\.network\//i, '').replace(/^\/+/, ''); }
 
-function layout(body, title = 'QR-V Issuer Portal') {
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(title)}</title><style>:root{--bg:#061126;--panel:#101f42;--line:#2d477a;--gold:#f2d06b;--cyan:#62cbff;--text:#eef4ff;--muted:#b7c6e6;--green:#22c55e;--red:#ef4444}*{box-sizing:border-box}body{margin:0;font-family:Inter,Arial,sans-serif;background:radial-gradient(circle at top,#14366f,#061126 52%,#030711);color:var(--text)}.wrap{max-width:1080px;margin:0 auto;padding:30px 20px}.nav{display:flex;justify-content:space-between;gap:16px;align-items:center}.brand{font-weight:900;letter-spacing:.08em}.nav a{color:#dbeafe;text-decoration:none;margin-left:14px}.hero,.card{background:rgba(16,31,66,.9);border:1px solid var(--line);border-radius:24px;padding:26px;margin-top:24px}h1{font-size:clamp(38px,7vw,72px);line-height:1;margin:10px 0}p,li{color:var(--muted);font-size:17px;line-height:1.6}.eyebrow{color:var(--gold);font-size:13px;text-transform:uppercase;letter-spacing:.14em;font-weight:900}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}.btn,button{display:inline-block;border:0;border-radius:999px;background:var(--gold);color:#071126;font-weight:900;padding:13px 18px;text-decoration:none;cursor:pointer}.btn.alt{background:transparent;border:1px solid var(--line);color:#fff}input,textarea{width:100%;padding:14px;border-radius:14px;border:1px solid #3a5288;background:#081735;color:#fff;font-size:16px}label{display:block;margin:12px 0 6px;font-weight:800}.mono{font-family:ui-monospace,Menlo,monospace;color:#dbeafe;word-break:break-word}.success{border-left:4px solid var(--green)}.error{border-left:4px solid var(--red)}@media(max-width:800px){.grid{grid-template-columns:1fr}.nav{align-items:flex-start;flex-direction:column}.nav a{margin:0 10px 0 0}}</style></head><body><div class="wrap"><nav class="nav"><div class="brand">QR-V™ ISSUER</div><div><a href="${VERIFY_BASE_URL}">Verify</a><a href="${REGISTRY_BASE_URL}">Registry</a><a href="/health">Health</a></div></nav>${body}</div></body></html>`;
+const networkCards = [
+  { host: 'qrv.network', label: 'Root site', url: URLS.site, body: 'Product, trust, pricing, and route-specific public pages for the QR-V Network.' },
+  { host: 'verify.qrv.network', label: 'Verifier', url: URLS.verify, body: 'Public QRVID lookup destination for recipients, auditors, and relying parties.' },
+  { host: 'registry.qrv.network', label: 'Registry', url: URLS.registry, body: 'Record authority, lifecycle state, revocation status, and registry API surface.' },
+  { host: 'api.qrv.network', label: 'API', url: URLS.api, body: 'Programmatic QRVID issuance, verification, status, webhook, and network endpoints.' },
+  { host: 'issuer.qrv.network', label: 'Issuer', url: URLS.issuer, body: 'Issuer portal for creating QR-V Verified Certificates and managed records.' },
+  { host: 'docs.qrv.network', label: 'Docs', url: URLS.docs, body: 'Implementation guides, API references, verification patterns, and examples.' },
+  { host: 'developers.qrv.network', label: 'Developers', url: URLS.developers, body: 'Developer onboarding, SDK direction, sandboxes, and integration resources.' },
+  { host: 'status.qrv.network', label: 'Status', url: URLS.status, body: 'Operational availability, maintenance notices, and incident communications.' }
+];
+
+const useCases = [
+  { slug: '/use-cases/certificates', title: 'Certificates', short: 'Make educational, training, course, award, and compliance certificates instantly verifiable.', icon: '◈' },
+  { slug: '/use-cases/membership-id', title: 'Membership ID', short: 'Give members a QRVID-backed proof that can be checked without exposing private account data.', icon: '◆' },
+  { slug: '/use-cases/product-authentication', title: 'Product Authentication', short: 'Attach verification to product labels, lots, serials, limited editions, and after-market authenticity checks.', icon: '◇' },
+  { slug: '/use-cases/document-verification', title: 'Document Verification', short: 'Bind documents to a registry record so recipients can confirm status and issuer identity.', icon: '▣' },
+  { slug: '/use-cases/asset-records', title: 'Asset Records', short: 'Publish verifiable status records for equipment, property, collectibles, and controlled assets.', icon: '▤' }
+];
+
+const pricingPlans = [
+  { name: 'Starter Issuer', price: '$99/mo', audience: 'Small certificate issuers and pilots', features: ['Issue QR-V Verified Certificates', 'Hosted verification links', 'Basic issuer profile', 'Email support'] },
+  { name: 'Growth Issuer', price: '$299/mo', audience: 'Growing teams with recurring issuance', features: ['Higher monthly issuance capacity', 'Batch-ready workflows', 'Registry status controls', 'Priority onboarding'] },
+  { name: 'Professional Issuer', price: '$799/mo', audience: 'Operational teams and trust-sensitive programs', features: ['Advanced issuer controls', 'Custom verification branding options', 'Revocation and status workflows', 'Integration planning'] },
+  { name: 'Enterprise / Network Issuer', price: 'Custom', audience: 'Institutions, networks, and high-volume deployments', features: ['Dedicated launch architecture', 'Custom contracts and compliance review', 'API and portal alignment', 'Support and SLA options'] }
+];
+
+function verificationForm() {
+  return `<form class="verify-form" method="post" action="/verify" aria-label="Verify a QRVID"><label for="qrvid">Verify any QRVID</label><div class="verify-row"><input id="qrvid" name="qrvid" inputmode="latin" autocomplete="off" placeholder="QRV-CERT-000001" required><button type="submit">Verify</button></div><small>Redirects to ${escapeHtml(URLS.verify)}/{QRVID}</small></form>`;
 }
 
+function liveNetworkSection() {
+  return `<section class="section" id="network"><div class="section-head"><p class="eyebrow">Live Network</p><h2>One trust network, purpose-built subdomains.</h2><p>QR-V separates verification, registry, issuer, API, documentation, developer, and status responsibilities across clear production endpoints.</p></div><div class="grid four">${networkCards.map(card => `<a class="network-card" href="${escapeHtml(card.url)}"><span>${escapeHtml(card.label)}</span><strong>${escapeHtml(card.host)}</strong><p>${escapeHtml(card.body)}</p></a>`).join('')}</div></section>`;
+}
+
+function disclaimerBlock() {
+  return `<section class="disclaimer"><strong>Trust and legal notice.</strong> QR-V provides registry-backed verification infrastructure and public status pages. QR-V does not automatically certify the truth, legality, ownership, identity, regulatory standing, or fitness of issuer-supplied content. Relying parties should review issuer identity, record scope, jurisdiction, applicable law, and the current verification status before making decisions.</section>`;
+}
+
+function layout({ title = 'QR-V Network', description = 'QR-V Network turns QR codes into registry-backed verification records.', path = '/', body }) {
+  const canonical = `${URLS.site}${path === '/' ? '' : path}`;
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(description)}">
+<link rel="canonical" href="${escapeHtml(canonical)}">
+<style>
+:root{--bg:#050914;--panel:#0d1730;--panel2:#101f42;--line:#263a67;--gold:#f2d06b;--cyan:#66d9ff;--text:#f3f7ff;--muted:#b9c8e8;--green:#22c55e;--red:#ef4444;--shadow:0 30px 90px rgba(0,0,0,.36)}*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:radial-gradient(circle at 15% 0,#143c76 0,#08142c 32%,#050914 72%);color:var(--text)}a{color:inherit}.wrap{max-width:1180px;margin:0 auto;padding:0 22px}.top{position:sticky;top:0;z-index:10;background:rgba(5,9,20,.82);backdrop-filter:blur(16px);border-bottom:1px solid rgba(255,255,255,.08)}.nav{display:flex;align-items:center;justify-content:space-between;gap:20px;padding:16px 0}.brand{display:flex;align-items:center;gap:10px;text-decoration:none;font-weight:950;letter-spacing:.06em}.mark{display:grid;place-items:center;width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,var(--gold),#fff1a8);color:#061126;box-shadow:0 0 40px rgba(242,208,107,.25)}.links{display:flex;gap:16px;align-items:center;flex-wrap:wrap}.links a{text-decoration:none;color:#dbeafe;font-weight:750;font-size:14px}.links a:hover{color:#fff}.hero{padding:74px 0 36px}.hero-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:stretch}.hero-card,.section,.card,.network-card,.disclaimer{background:linear-gradient(180deg,rgba(16,31,66,.94),rgba(8,18,39,.92));border:1px solid var(--line);border-radius:28px;box-shadow:var(--shadow)}.hero-card{padding:42px}.eyebrow{margin:0 0 10px;color:var(--gold);font-size:13px;text-transform:uppercase;letter-spacing:.16em;font-weight:950}h1{font-size:clamp(42px,7vw,76px);line-height:.95;margin:10px 0 18px;letter-spacing:-.055em}h2{font-size:clamp(30px,4vw,48px);line-height:1.05;margin:0 0 14px;letter-spacing:-.035em}h3{font-size:24px;margin:0 0 10px}p,li{color:var(--muted);font-size:17px;line-height:1.65}.lead{font-size:21px;color:#deebff}.actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:24px}.btn,button{display:inline-flex;align-items:center;justify-content:center;border:0;border-radius:999px;background:var(--gold);color:#061126;font-weight:950;padding:13px 18px;text-decoration:none;cursor:pointer;min-height:46px}.btn.alt{background:transparent;border:1px solid var(--line);color:#fff}.btn.dark{background:#10244c;color:#fff;border:1px solid #37568e}.verify-panel{padding:26px}.verify-form{display:grid;gap:10px}.verify-row{display:grid;grid-template-columns:1fr auto;gap:10px}.verify-form label,label{font-weight:900;color:#fff}.verify-form small{color:#9fb1d6}input,textarea{width:100%;padding:14px 15px;border-radius:16px;border:1px solid #3a5288;background:#081735;color:#fff;font-size:16px;outline:none}input:focus,textarea:focus{border-color:var(--cyan);box-shadow:0 0 0 4px rgba(102,217,255,.12)}.section{margin:24px 0;padding:32px}.section-head{max-width:780px}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:18px}.grid.two{grid-template-columns:repeat(2,1fr)}.grid.four{grid-template-columns:repeat(4,1fr)}.card{padding:24px}.card .icon{font-size:30px;color:var(--gold)}.network-card{padding:19px;text-decoration:none;transition:transform .16s,border-color .16s}.network-card:hover{transform:translateY(-3px);border-color:var(--cyan)}.network-card span{display:inline-block;color:var(--gold);font-size:12px;text-transform:uppercase;letter-spacing:.12em;font-weight:950;margin-bottom:8px}.network-card strong{display:block;font-size:18px;word-break:break-word}.network-card p{font-size:14px;margin-bottom:0}.pill-list{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}.pill{border:1px solid var(--line);border-radius:999px;padding:9px 12px;color:#dbeafe;background:rgba(255,255,255,.04);font-weight:800}.quote{border-left:4px solid var(--gold);padding-left:18px;color:#e8f1ff}.disclaimer{padding:20px;margin:24px 0;color:#b9c8e8}.footer{padding:34px 0 60px;color:#9fb1d6}.footer-grid{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;border-top:1px solid rgba(255,255,255,.1);padding-top:24px}.footer a{color:#c9d8f5;text-decoration:none;margin-right:14px}.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}.status-ok{color:var(--green);font-weight:950}.status-warn{color:var(--gold);font-weight:950}.route-title{padding:54px 0 6px}@media(max-width:980px){.hero-grid,.grid,.grid.two,.grid.four{grid-template-columns:1fr}.links{display:none}.hero{padding-top:42px}.hero-card{padding:28px}.verify-row{grid-template-columns:1fr}.section{padding:24px}}
+</style>
+</head>
+<body>
+<header class="top"><div class="wrap"><nav class="nav"><a class="brand" href="/"><span class="mark">QV</span><span>QR-V Network</span></a><div class="links"><a href="/protocol">Protocol</a><a href="/how-it-works">How it works</a><a href="/registry">Registry</a><a href="/use-cases">Use cases</a><a href="/developers">Developers</a><a href="/pricing">Pricing</a><a href="/book-demo">Book demo</a></div></nav></div></header>
+<main class="wrap">${body}${disclaimerBlock()}</main>
+<footer class="wrap footer"><div class="footer-grid"><div><strong>QR-V Network</strong><p>Registry-backed QRVID verification for certificates, IDs, products, documents, and asset records.</p></div><div><a href="/security">Security</a><a href="/legal">Legal</a><a href="/privacy">Privacy</a><a href="/terms">Terms</a><a href="/status">Status</a></div></div></footer>
+</body></html>`;
+}
+
+function sendPage(res, page) { res.type('html').send(layout(page)); }
+
+function homePage() {
+  return { path: '/', title: 'QR-V Network | Registry-backed QRVID verification', description: 'The production root site for qrv.network and QR-V Verified Certificates.', body: `<section class="hero"><div class="hero-grid"><div class="hero-card"><p class="eyebrow">QR-V Verified Certificates</p><h1>Turn every certificate into a live verification record.</h1><p class="lead">QR-V gives issuers a registry-backed QRVID that lets recipients, employers, auditors, and customers verify status at the moment of trust.</p><div class="actions"><a class="btn" href="/book-demo">Book a demo</a><a class="btn alt" href="/protocol">Explore the protocol</a></div><div class="pill-list"><span class="pill">Issue</span><span class="pill">Verify</span><span class="pill">Revoke</span><span class="pill">Audit</span></div></div><div class="hero-card verify-panel">${verificationForm()}<hr style="border-color:rgba(255,255,255,.1);margin:24px 0"><h3>First product positioning</h3><p><strong>QR-V Verified Certificates</strong> are the first commercial QR-V product: a verification layer for credentials that need clear issuer identity, current status, and durable lookup.</p></div></div></section><section class="section"><p class="eyebrow">What QR-V does</p><h2>QR codes are easy to copy. QRVIDs are records you can verify.</h2><div class="grid"><div class="card"><h3>Registry-backed</h3><p>Each QRVID resolves to a record with issuer context, record type, lifecycle status, and verification metadata.</p></div><div class="card"><h3>Route-specific</h3><p>Separate product, protocol, registry, use case, developer, pricing, status, security, and legal pages support production discovery.</p></div><div class="card"><h3>Trust-aware</h3><p>Public status and legal disclaimers clarify what the network proves, what issuers attest, and what relying parties must review.</p></div></div></section>${liveNetworkSection()}` };
+}
+
+function standardPage({ path, title, eyebrow, heading, lead, cards = [], extra = '' }) {
+  return { path, title: `${title} | QR-V Network`, description: lead, body: `<section class="route-title"><p class="eyebrow">${escapeHtml(eyebrow)}</p><h1>${escapeHtml(heading)}</h1><p class="lead">${escapeHtml(lead)}</p><div class="actions"><a class="btn" href="/book-demo">Book a demo</a><a class="btn alt" href="/pricing">View pricing</a></div></section><section class="section"><div class="grid ${cards.length === 2 ? 'two' : ''}">${cards.map(card => `<div class="card"><div class="icon">${card.icon || '•'}</div><h3>${escapeHtml(card.title)}</h3><p>${escapeHtml(card.body)}</p></div>`).join('')}</div></section>${extra}` };
+}
+
+function pricingPage() {
+  return { path: '/pricing', title: 'Pricing | QR-V Network', description: 'QR-V pricing for Starter, Growth, Professional, Enterprise, and Launch Packages.', body: `<section class="route-title"><p class="eyebrow">Pricing</p><h1>Issuer plans for every stage of verification.</h1><p class="lead">Start with QR-V Verified Certificates, then expand into higher-volume issuance, integrations, and network-level deployments.</p></section><section class="section"><div class="grid four">${pricingPlans.map(plan => `<div class="card"><p class="eyebrow">${escapeHtml(plan.audience)}</p><h3>${escapeHtml(plan.name)}</h3><h2>${escapeHtml(plan.price)}</h2><ul>${plan.features.map(feature => `<li>${escapeHtml(feature)}</li>`).join('')}</ul><a class="btn" href="/book-demo">Discuss plan</a></div>`).join('')}</div></section><section class="section"><p class="eyebrow">Launch Packages</p><h2>Launch with the records, pages, and rollout support already mapped.</h2><div class="grid"><div class="card"><h3>Certificate launch</h3><p>Issuer profile setup, first QR-V Verified Certificate workflow, pilot records, and verification-page readiness.</p></div><div class="card"><h3>Integration launch</h3><p>API route planning, issuance workflow mapping, registry status model, and developer handoff.</p></div><div class="card"><h3>Network launch</h3><p>Multi-issuer program design, legal review support, production acceptance checklist, and operational runbook.</p></div></div></section>` };
+}
+
+function useCasesPage() {
+  return { path: '/use-cases', title: 'Use Cases | QR-V Network', description: 'QR-V use cases for certificates, membership IDs, product authentication, document verification, and asset records.', body: `<section class="route-title"><p class="eyebrow">Use cases</p><h1>Verification patterns for trust-sensitive records.</h1><p class="lead">QR-V works when a recipient needs to know whether a QR code points to a current registry-backed record from an accountable issuer.</p></section><section class="section"><div class="grid">${useCases.map(item => `<a class="card" href="${item.slug}" style="text-decoration:none"><div class="icon">${item.icon}</div><h3>${escapeHtml(item.title)}</h3><p>${escapeHtml(item.short)}</p></a>`).join('')}</div></section>` };
+}
+
+function useCaseDetail(item, body) {
+  return standardPage({ path: item.slug, title: item.title, eyebrow: 'Use case', heading: `QR-V for ${item.title}`, lead: item.short, cards: [
+    { title: 'Record binding', body: 'Bind a public QRVID to issuer-supplied details, status, verification context, and a durable lookup URL.', icon: item.icon },
+    { title: 'Relying-party check', body: 'Give viewers a simple path to verify status before accepting a credential, product claim, document, ID, or asset record.', icon: '✓' },
+    { title: 'Lifecycle status', body: 'Support active, revoked, replaced, expired, or superseded states depending on issuer policy and product scope.', icon: '↻' }
+  ], extra: `<section class="section"><h2>Production fit</h2><p>${escapeHtml(body)}</p>${verificationForm()}</section>` });
+}
+
+const pages = new Map();
+function add(path, factory) { pages.set(path, factory); }
+
+add('/', homePage);
+add('/protocol', () => standardPage({ path: '/protocol', title: 'Protocol', eyebrow: 'Protocol', heading: 'A practical protocol for QRVID verification.', lead: 'QR-V defines how issuers create records, how registry status is exposed, and how relying parties verify what a QR code claims.', cards: [
+  { title: 'QRVID namespace', body: 'A QRVID is a human-readable identifier that resolves to a verification URL and registry-backed status.', icon: 'ID' },
+  { title: 'Issuer attestation', body: 'Issuers publish record details and accept responsibility for the claims they put into the registry.', icon: '✦' },
+  { title: 'Verifier response', body: 'Verification pages surface current state, issuer context, and trust notices in a consistent format.', icon: '↗' }
+], extra: liveNetworkSection() }));
+add('/how-it-works', () => standardPage({ path: '/how-it-works', title: 'How it works', eyebrow: 'Workflow', heading: 'Issue, attach, scan, verify, and manage.', lead: 'QR-V is designed for simple operational adoption: create a record, attach the QRVID, and let recipients verify status online.', cards: [
+  { title: '1. Issuer creates', body: 'The issuer creates a QR-V Verified Certificate or other record with approved metadata.', icon: '1' },
+  { title: '2. QRVID attaches', body: 'The QRVID appears on a PDF, badge, label, product, document, or asset page.', icon: '2' },
+  { title: '3. Viewer verifies', body: 'A scan opens verify.qrv.network/{QRVID}, where current status and context are displayed.', icon: '3' },
+  { title: '4. Issuer manages', body: 'Issuers can revoke, replace, or update records according to their policy and plan.', icon: '4' }
+] }));
+add('/registry', () => standardPage({ path: '/registry', title: 'Registry', eyebrow: 'Registry', heading: 'The registry is the source of verification status.', lead: 'The QR-V registry supports record creation, public lookup, lifecycle state, revocation, and audit-oriented metadata.', cards: [
+  { title: 'Lookup', body: 'Public verification can resolve a QRVID to the registry status needed for a relying-party decision.', icon: '⌕' },
+  { title: 'Lifecycle', body: 'Records can be active, revoked, expired, replaced, or otherwise marked under issuer policy.', icon: '◷' },
+  { title: 'Audit trail', body: 'Registry metadata helps explain when a record was issued, by whom, and what status it currently has.', icon: '▥' }
+], extra: `<section class="section"><h2>Registry endpoint</h2><p class="mono">${escapeHtml(URLS.registry)}</p><a class="btn" href="${escapeHtml(URLS.registry)}">Open registry</a></section>` }));
+add('/use-cases', useCasesPage);
+for (const item of useCases) {
+  const copy = {
+    '/use-cases/certificates': 'Certificate programs benefit from visible issuer identity, recipient-friendly lookup, revocation support, and verification pages suitable for employers, auditors, and reviewers.',
+    '/use-cases/membership-id': 'Membership IDs can be checked at doors, online workflows, support desks, partner locations, or events without relying only on a static printed badge.',
+    '/use-cases/product-authentication': 'Products can carry QRVIDs that support authenticity checks, lot context, serial records, warranty confidence, and customer-facing verification journeys.',
+    '/use-cases/document-verification': 'Documents can include a verification URL that confirms whether the issuer still recognizes the document as current, valid, replaced, or revoked.',
+    '/use-cases/asset-records': 'Asset records can expose controlled public verification for equipment, collectibles, property, or internal assets that need durable status checks.'
+  }[item.slug];
+  add(item.slug, () => useCaseDetail(item, copy));
+}
+add('/developers', () => standardPage({ path: '/developers', title: 'Developers', eyebrow: 'Developers', heading: 'Build issuance and verification into your workflow.', lead: 'Developers can integrate with QR-V API endpoints, link to public verification, and design issuer workflows around record lifecycle states.', cards: [
+  { title: 'API-first', body: 'Use api.qrv.network for programmatic issuance, verification, and operational integrations as plans mature.', icon: '{ }' },
+  { title: 'Verification URLs', body: 'Every QRVID can route to verify.qrv.network/{QRVID}, making linking and QR generation simple.', icon: '/' },
+  { title: 'Docs and status', body: 'Use docs, developer resources, and status pages to plan reliable production rollouts.', icon: '⌘' }
+], extra: `<section class="section"><h2>Developer endpoints</h2><p class="mono">API: ${escapeHtml(URLS.api)}</p><p class="mono">Docs: ${escapeHtml(URLS.docs)}</p><p class="mono">Developers: ${escapeHtml(URLS.developers)}</p></section>` }));
+add('/pricing', pricingPage);
+add('/book-demo', () => ({ path: '/book-demo', title: 'Book a Demo | QR-V Network', description: 'Book a QR-V demo for verified certificates and issuer workflows.', body: `<section class="route-title"><p class="eyebrow">Book demo</p><h1>Plan your first QR-V Verified Certificate launch.</h1><p class="lead">Tell us what you issue, who verifies it, and what trust decision the verification page must support.</p></section><section class="section"><div class="grid two"><div class="card"><h3>Demo agenda</h3><ul><li>Issuer and recipient workflow mapping</li><li>Certificate or record type selection</li><li>Verification-page content review</li><li>Pricing and launch package fit</li></ul></div><div class="card"><h3>Contact</h3><p>Use your existing QR-V sales/contact channel or connect through the issuer portal.</p><p><a class="btn" href="${escapeHtml(URLS.issuer)}">Open issuer portal</a></p></div></div></section>` }));
+add('/about', () => standardPage({ path: '/about', title: 'About', eyebrow: 'About', heading: 'QR-V is verification infrastructure for real-world records.', lead: 'The network exists to make scanned credentials, IDs, products, documents, and assets easier to validate and easier to govern.', cards: [
+  { title: 'Mission', body: 'Reduce uncertainty around QR-based claims by connecting every code to live status and issuer context.', icon: '★' },
+  { title: 'Focus', body: 'Start with QR-V Verified Certificates, then extend the same pattern to other record categories.', icon: '→' },
+  { title: 'Principle', body: 'Be clear about what QR-V verifies and what remains an issuer, legal, or relying-party responsibility.', icon: '!' }
+] }));
+add('/status', () => ({ path: '/status', title: 'Status | QR-V Network', description: 'QR-V network status routes and health checks.', body: `<section class="route-title"><p class="eyebrow">Status</p><h1>Network status and runtime checks.</h1><p class="lead">Use the public status page for incidents and the local health endpoints for deployment monitoring.</p></section><section class="section"><div class="grid"><div class="card"><h3>Public status</h3><p class="status-ok">Configured</p><p class="mono">${escapeHtml(URLS.status)}</p><a class="btn" href="${escapeHtml(URLS.status)}">Open status</a></div><div class="card"><h3>Health endpoints</h3><p class="mono">/health /healthz /ready /readyz /version /ping</p></div><div class="card"><h3>Runtime</h3><p class="mono">Node 20.x compatible Express server.js</p><p class="mono">Version ${escapeHtml(VERSION)}</p></div></div></section>${liveNetworkSection()}` }));
+add('/security', () => standardPage({ path: '/security', title: 'Security', eyebrow: 'Security', heading: 'Security is built around clear trust boundaries.', lead: 'QR-V separates issuer claims, registry status, public verification, operational monitoring, and relying-party responsibility.', cards: [
+  { title: 'No hidden import wrappers', body: 'The app starts directly from server.js for predictable Hostinger deployment and Node 20.x compatibility.', icon: '✓' },
+  { title: 'Rate limited', body: 'Runtime requests are rate limited to reduce abuse against the marketing site and verification redirect form.', icon: '⏱' },
+  { title: 'Scoped redirects', body: 'The QRVID form only redirects to the configured verification host using the submitted identifier as a path segment.', icon: '↪' }
+] }));
+add('/legal', () => standardPage({ path: '/legal', title: 'Legal', eyebrow: 'Legal', heading: 'Legal and trust disclaimers.', lead: 'QR-V is infrastructure. Issuers remain responsible for issuer-supplied content, authority, compliance, and record claims.', cards: [
+  { title: 'Issuer responsibility', body: 'Issuers are responsible for the accuracy, authorization, and compliance of records they publish.', icon: '§' },
+  { title: 'No universal endorsement', body: 'A QR-V status page does not mean QR-V endorses the issuer, recipient, product, asset, or underlying claim.', icon: '!' },
+  { title: 'Relying-party review', body: 'Relying parties should check current status, scope, issuer identity, and applicable laws before acting.', icon: '✓' }
+] }));
+add('/privacy', () => standardPage({ path: '/privacy', title: 'Privacy', eyebrow: 'Privacy', heading: 'Privacy notice for the public QR-V site.', lead: 'The public site is designed to minimize data collection while supporting verification, operations, analytics, security, and support.', cards: [
+  { title: 'Verification data', body: 'Public verification may show issuer-provided record details necessary for relying-party review.', icon: '◌' },
+  { title: 'Operational data', body: 'Logs may include IP address, user agent, route, timestamp, and security signals needed to operate the service.', icon: '⌁' },
+  { title: 'Issuer data', body: 'Issuer portal and API data are governed by applicable agreements, product settings, and jurisdictional requirements.', icon: '▣' }
+] }));
+add('/terms', () => standardPage({ path: '/terms', title: 'Terms', eyebrow: 'Terms', heading: 'Terms summary for QR-V Network use.', lead: 'Use of QR-V is subject to applicable agreements, acceptable-use requirements, issuer responsibilities, and verification disclaimers.', cards: [
+  { title: 'Acceptable use', body: 'Do not use QR-V for unlawful, deceptive, harmful, infringing, or unauthorized records.', icon: '✓' },
+  { title: 'Availability', body: 'Network availability can vary due to maintenance, incidents, third-party services, or deployment conditions.', icon: '◷' },
+  { title: 'Changes', body: 'Product features, pricing, routing, and terms may evolve as the network matures.', icon: '↻' }
+] }));
+
 async function createRegistryRecord({ type, issuer, owner, payload }) {
-  const response = await fetch(`${REGISTRY_BASE_URL}/registry/create`, {
+  const response = await fetch(`${URLS.registry}/registry/create`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ type, issuer, owner, payload })
@@ -42,7 +199,7 @@ async function createRegistryRecord({ type, issuer, owner, payload }) {
 }
 
 async function revokeRegistryRecord(qrvid, reason) {
-  const response = await fetch(`${REGISTRY_BASE_URL}/registry/${encodeURIComponent(qrvid)}/revoke`, {
+  const response = await fetch(`${URLS.registry}/registry/${encodeURIComponent(qrvid)}/revoke`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ reason })
@@ -52,37 +209,39 @@ async function revokeRegistryRecord(qrvid, reason) {
   return body;
 }
 
-app.get('/ping', (_req, res) => res.status(200).json({ ok: true }));
-app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'issuer-qrv', version: VERSION, timestamp: now() }));
-app.get('/healthz', (_req, res) => res.json({ status: 'ok' }));
-app.get('/version', (_req, res) => res.json({ service: 'issuer-qrv', version: VERSION, appBaseUrl: APP_BASE_URL, registryBaseUrl: REGISTRY_BASE_URL, verifyBaseUrl: VERIFY_BASE_URL }));
-app.get('/readyz', async (_req, res) => {
-  try {
-    const r = await fetch(`${REGISTRY_BASE_URL}/ready`, { headers: { accept: 'application/json' } });
-    const registry = await r.json().catch(() => ({}));
-    res.status(r.ok ? 200 : 503).json({ ready: r.ok, registry, writeAuthConfigured: Boolean(ISSUER_API_KEY) });
-  } catch (error) {
-    res.status(503).json({ ready: false, error: error.message, writeAuthConfigured: Boolean(ISSUER_API_KEY) });
-  }
-});
-
-app.get('/', (_req, res) => {
-  res.type('html').send(layout(`<section class="hero"><div class="eyebrow">QR-V™ Issuer Portal</div><h1>Issue verifiable records.</h1><p>Create registry-backed certificates and trust-sensitive records that resolve through QR-V public verification.</p><p><a class="btn" href="/issue">Issue Certificate</a> <a class="btn alt" href="${VERIFY_BASE_URL}">Open Verify Portal</a></p></section><section class="grid"><div class="card"><h3>Create</h3><p>Submit certificate metadata and create an authoritative registry entry.</p></div><div class="card"><h3>Bind</h3><p>Receive a QRVID and verification URL for documents, certificates, and credentials.</p></div><div class="card"><h3>Revoke</h3><p>Invalidate records when credentials are withdrawn or no longer current.</p></div></section><section class="card"><h2>Service Configuration</h2><p class="mono">Registry: ${REGISTRY_BASE_URL}</p><p class="mono">Verify: ${VERIFY_BASE_URL}</p><p class="mono">Write Auth Configured: ${ISSUER_API_KEY ? 'YES' : 'NO'}</p></section>`));
-});
+app.get('/ping', (_req, res) => res.status(200).type('text/plain').send('pong'));
+app.get('/health', (_req, res) => res.status(200).json({ status: 'ok', service: 'qrv-marketing-site', version: VERSION, timestamp: now() }));
+app.get('/healthz', (_req, res) => res.status(200).json({ status: 'ok' }));
+app.get('/ready', (_req, res) => res.status(200).json({ ready: true, service: 'qrv-marketing-site', version: VERSION, urls: URLS }));
+app.get('/readyz', (_req, res) => res.status(200).json({ ready: true }));
+app.get('/version', (_req, res) => res.status(200).json({ service: 'qrv-marketing-site', version: VERSION, node: process.version, urls: URLS }));
 
 app.get('/issue', (_req, res) => {
-  res.type('html').send(layout(`<section class="hero"><div class="eyebrow">Issue Certificate</div><h1>Create a QR-V certificate record.</h1><form method="post" action="/issue"><label>Issuer</label><input name="issuer" value="${escapeHtml(DEFAULT_ISSUER_NAME)}" required><label>Recipient / Subject</label><input name="owner" placeholder="Jane Smith" required><label>Certificate Title</label><input name="title" placeholder="Advanced Verification Certificate" required><label>Record Type</label><input name="type" value="certificate" required><label>Metadata</label><textarea name="metadata" rows="4" placeholder="Course, credential, program, or notes"></textarea><p><button type="submit">Create Verifiable Record</button></p></form></section>`));
+  sendPage(res, standardPage({ path: '/issue', title: 'Issue QR-V Certificate', eyebrow: 'Issuer utility', heading: 'Create a QR-V certificate record.', lead: 'This compatibility route preserves the issuer MVP form while the root site becomes the public qrv.network marketing site.', cards: [], extra: `<section class="section"><form method="post" action="/issue"><label>Issuer</label><input name="issuer" value="${escapeHtml(DEFAULT_ISSUER_NAME)}" required><label>Recipient / Subject</label><input name="owner" placeholder="Jane Smith" required><label>Certificate Title</label><input name="title" placeholder="Advanced Verification Certificate" required><label>Record Type</label><input name="type" value="certificate" required><label>Metadata</label><textarea name="metadata" rows="4" placeholder="Course, credential, program, or notes"></textarea><p><button type="submit">Create Verifiable Record</button></p></form></section>` }));
 });
 
 app.post('/issue', async (req, res) => {
   try {
     const { issuer, owner, title, type, metadata } = req.body;
-    const result = await createRegistryRecord({ type: type || 'certificate', issuer, owner, payload: { title, metadata, source: 'issuer-qrv', issuedAt: now() } });
-    const verifyUrl = result.verifyUrl || `${VERIFY_BASE_URL}/${result.qrvid}`;
-    res.type('html').send(layout(`<section class="card success"><h1>Record Issued</h1><p>Certificate record created successfully.</p><p><strong>QRVID</strong></p><p class="mono">${escapeHtml(result.qrvid)}</p><p><strong>Hash</strong></p><p class="mono">${escapeHtml(result.hash)}</p><p><a class="btn" href="${verifyUrl}">Open Verification Page</a> <a class="btn alt" href="/issue">Issue Another</a></p></section>`,'Record Issued'));
+    const result = await createRegistryRecord({ type: type || 'certificate', issuer, owner, payload: { title, metadata, source: 'qrv-network-root', issuedAt: now() } });
+    const verifyUrl = result.verifyUrl || `${URLS.verify}/${encodeURIComponent(result.qrvid)}`;
+    sendPage(res, { path: '/issue', title: 'Record Issued | QR-V Network', description: 'Record issued.', body: `<section class="route-title"><p class="eyebrow">Issued</p><h1>Record issued.</h1><p class="lead">Certificate record created successfully.</p></section><section class="section"><p><strong>QRVID</strong></p><p class="mono">${escapeHtml(result.qrvid)}</p><p><strong>Hash</strong></p><p class="mono">${escapeHtml(result.hash)}</p><a class="btn" href="${escapeHtml(verifyUrl)}">Open verification page</a> <a class="btn alt" href="/issue">Issue another</a></section>` });
   } catch (error) {
-    res.status(500).type('html').send(layout(`<section class="card error"><h1>Issue Failed</h1><p>${escapeHtml(error.message)}</p><p><a class="btn" href="/issue">Try Again</a></p></section>`,'Issue Failed'));
+    res.status(500);
+    sendPage(res, { path: '/issue', title: 'Issue Failed | QR-V Network', description: 'Issue failed.', body: `<section class="route-title"><p class="eyebrow">Error</p><h1>Issue failed.</h1><p class="lead">${escapeHtml(error.message)}</p><a class="btn" href="/issue">Try again</a></section>` });
   }
+});
+
+app.post('/verify', (req, res) => {
+  const qrvid = cleanQrvid(req.body?.qrvid);
+  if (!qrvid) return res.redirect(303, '/');
+  return res.redirect(303, `${URLS.verify}/${encodeURIComponent(qrvid)}`);
+});
+
+app.get('/verify', (req, res) => {
+  const qrvid = cleanQrvid(req.query?.qrvid);
+  if (!qrvid) return res.redirect(302, URLS.verify);
+  return res.redirect(302, `${URLS.verify}/${encodeURIComponent(qrvid)}`);
 });
 
 app.post('/api/issue', async (req, res) => {
@@ -105,7 +264,14 @@ app.post('/api/revoke/:qrvid', async (req, res) => {
   }
 });
 
-app.use((req, res) => res.status(404).type('html').send(layout(`<section class="card error"><h1>Not Found</h1><p>The requested issuer route does not exist.</p><p class="mono">${escapeHtml(req.path)}</p></section>`, 'Not Found')));
+for (const [path, factory] of pages.entries()) {
+  app.get(path, (_req, res) => sendPage(res, factory()));
+}
+
+app.use((req, res) => {
+  res.status(404);
+  sendPage(res, { path: req.path, title: 'Not Found | QR-V Network', description: 'QR-V route not found.', body: `<section class="route-title"><p class="eyebrow">404</p><h1>Route not found.</h1><p class="lead">The requested QR-V Network page does not exist.</p><p class="mono">${escapeHtml(req.path)}</p><div class="actions"><a class="btn" href="/">Return home</a><a class="btn alt" href="/use-cases">View use cases</a></div></section>` });
+});
 
 app.use((err, _req, res, _next) => {
   const status = err.status || 500;
@@ -113,7 +279,7 @@ app.use((err, _req, res, _next) => {
   res.status(status).json({ error: message });
 });
 
-const server = app.listen(PORT, '0.0.0.0', () => console.log(`issuer-qrv running on ${PORT}`));
+const server = app.listen(PORT, '0.0.0.0', () => console.log(`qrv-marketing-site running on ${PORT}`));
 server.on('error', (error) => console.error('Server startup error:', error));
 
 process.on('SIGTERM', () => server.close(() => process.exit(0)));


### PR DESCRIPTION
### Motivation

- Replace the issuer-only MVP with a production root marketing site for `qrv.network` that exposes route-specific pages, Live Network links, pricing, use-cases, and trust/legal disclaimers.  
- Provide a global QRVID verification entry point that reliably redirects viewers to the canonical verifier host.  
- Preserve Hostinger compatibility by keeping a single `server.js` entry, `npm start`, and Node 20.x engine requirements.

### Description

- Rewrote `server.js` to serve a marketing site and register the required public routes (including `/`, `/protocol`, `/how-it-works`, `/registry`, `/use-cases` and detailed subroutes, `/developers`, `/pricing`, `/book-demo`, `/about`, `/status`, `/security`, `/legal`, `/privacy`, `/terms`) and kept issuer compatibility routes (`/issue`, `POST /issue`, `POST /api/issue`, `POST /api/revoke/:qrvid`).
- Added a global QRVID verification form and safe redirect handlers (`POST /verify`, `GET /verify`) that normalize identifiers and redirect with HTTP 303/302 to `https://verify.qrv.network/{QRVID}`.  
- Introduced Live Network cards, use-case pages, pricing plans (Starter, Growth, Professional, Enterprise / Network, and Launch Packages), and a trust/legal disclaimer section rendered by the site.  
- Added/standardized health and runtime endpoints: `/health`, `/healthz`, `/ready`, `/readyz`, `/version`, and `/ping`, and made registry API calls use normalized public URL config via `URLS`.  
- Updated repository metadata and config: `package.json` (name → `qrv-marketing-site`, version → `1.2.0`, `engines.node` → `20.x`), full `.env.example` with public QR-V URLs and compatibility aliases, and an updated `README.md` containing Hostinger deployment instructions and route inventory.

### Testing

- Ran `npm install` successfully to ensure dependencies are present.  
- Ran `npm run check` (`node --check server.js`) and it reported no syntax errors.  
- Launched the app locally with `PORT=3126 npm start` and validated `/health` and `/ready` returned expected JSON and that `POST /verify` responded with `303 See Other` and `Location: https://verify.qrv.network/QRV-CERT-000001`, confirming the verification redirect behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2555779068832d83bd24111e351f4a)