### PR TITLE
Consolidate QRV.network root command hub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,28 @@
 # QR-V Network production root site configuration
 NODE_ENV=production
+APP_ENV=production
 PORT=3000
 APP_VERSION=1.2.0
+TZ=UTC
+LOG_LEVEL=info
 
 # Hostinger / public root site
 APP_BASE_URL=https://qrv.network
 QRV_PUBLIC_SITE_URL=https://qrv.network
+HOST_ROLE=marketing
+NEXT_PUBLIC_APP_ROLE=marketing
 
-# Public QR-V Network URLs used by route pages and Live Network cards
+# Public QR-V Network URLs used by route pages and Network Directory cards
 QRV_VERIFY_URL=https://verify.qrv.network
+QRV_ISSUER_URL=https://issuer.qrv.network
 QRV_REGISTRY_URL=https://registry.qrv.network
 QRV_API_URL=https://api.qrv.network
-QRV_ISSUER_URL=https://issuer.qrv.network
 QRV_DOCS_URL=https://docs.qrv.network
 QRV_DEVELOPERS_URL=https://developers.qrv.network
 QRV_STATUS_URL=https://status.qrv.network
+QRV_ADMIN_URL=https://admin.qrv.network
+QRV_STORE_URL=https://store.qrv.network
+QRV_SECURITY_URL=https://security.qrv.network
 
 # Compatibility aliases for existing QR-V services and legacy scripts
 VERIFY_BASE_URL=https://verify.qrv.network
@@ -22,39 +30,26 @@ REGISTRY_BASE_URL=https://registry.qrv.network
 NEXT_PUBLIC_QRV_API_BASE_URL=https://api.qrv.network
 NEXT_PUBLIC_QRV_VERIFY_BASE_URL=https://verify.qrv.network
 NEXT_PUBLIC_QRV_REGISTRY_BASE_URL=https://registry.qrv.network
-REGISTRY_BASE_URL=https://registry.qrv.network
-CORS_ALLOWED_ORIGINS=https://issuer.qrv.network,https://verify.qrv.network,https://qrv.network
 NEXT_PUBLIC_QRV_API_BASE=https://api.qrv.network
-NEXT_PUBLIC_APP_ROLE=marketing
-HOST_ROLE=marketing
+CORS_ALLOWED_ORIGINS=https://qrv.network,https://verify.qrv.network,https://registry.qrv.network,https://api.qrv.network,https://issuer.qrv.network,https://docs.qrv.network,https://developers.qrv.network,https://status.qrv.network,https://store.qrv.network
 
 # Optional issuer/registry write credentials for compatibility issuer routes only
 ISSUER_API_KEY=
 REGISTRY_API_KEY=
 DEFAULT_ISSUER_NAME=QR-V Demo Issuer
+DEFAULT_RECORD_PREFIX=QRV-CERT
 
 # Runtime tuning (Hostinger production pattern)
-NODE_ENV=production
-APP_ENV=production
-PORT=3000
-APP_VERSION=1.1.0
-TZ=UTC
-LOG_LEVEL=info
-HOST_ROLE=issuer
-RATE_LIMIT_WINDOW_MS=60000
-RATE_LIMIT_MAX=120
-PGSSLMODE=require
-NEXT_PUBLIC_QRV_API_BASE=https://api.qrv.network
-NEXT_PUBLIC_APP_ROLE=issuer
-# Runtime tuning
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=180
-CORS_ALLOWED_ORIGINS=https://qrv.network,https://verify.qrv.network,https://registry.qrv.network,https://api.qrv.network,https://issuer.qrv.network,https://docs.qrv.network,https://developers.qrv.network,https://status.qrv.network
+PGSSLMODE=require
 
 # Optional billing placeholders retained for issuer/payment integrations
 STRIPE_SECRET_KEY=sk_live_replace_me
 STRIPE_WEBHOOK_SECRET=whsec_replace_me
-STRIPE_PRICE_STARTER=price_replace_starter_99
-STRIPE_PRICE_GROWTH=price_replace_growth_299
+STRIPE_PRICE_STARTER=price_replace_starter_199
+STRIPE_PRICE_GROWTH=price_replace_growth_499
+STRIPE_PRICE_PROFESSIONAL=price_replace_professional_1500
+STRIPE_PRICE_ENTERPRISE=price_replace_enterprise_5000
 STRIPE_SUCCESS_URL=https://issuer.qrv.network/billing/success?session_id={CHECKOUT_SESSION_ID}
 STRIPE_CANCEL_URL=https://issuer.qrv.network/billing/cancel

--- a/README.md
+++ b/README.md
@@ -1,25 +1,76 @@
-# issuer-qrv
+# QR-V Network root site (`qrv.network`)
 
-QR-V issuer portal and certificate issuance control plane for `issuer.qrv.network`.
+This repository runs the production root-domain command hub for **QRV.network** as a Hostinger-compatible Node/Express application. The root domain consolidates navigation, commercial messaging, demos, status links, and service discovery without removing the operational subdomains.
 
 ## Production role
 
-This service is the issuer onboarding and monetization layer. It lets authorized issuers create QRVID-backed records, generate verification URLs and QR codes, revoke records, track verification scans, and confirm billing/API-key readiness.
+`qrv.network` is the public command hub for the QR-V service family. Operational trust surfaces remain separated so the public verifier, issuer app, registry authority, API gateway, documentation, monitoring, commerce, and internal operations can be deployed, monitored, and secured independently.
 
-## Public routes
+## Root-domain routes
 
-- `/login` — issuer sign-in handoff page for edge-managed authentication.
-- `/dashboard` — operational overview with issued records, scan counts, registry readiness, and audit events.
-- `/records` — list records issued during the current portal runtime.
-- `/records/new` — create a new registry-backed QR-V record.
-- `/certificates` — certificate-oriented alias for record creation.
-- `/issue` — issue form and POST handler.
-- `/revoke` — revoke form and POST handler.
-- `/api-keys` — issuer API-key setup and automation endpoint reference.
-- `/settings` — production URL and runtime configuration check.
-- `/billing` — commercial plan and Stripe readiness page.
+The root site serves route-specific pages for:
 
-## API routes
+- `/` — public command hub with verification entry, network directory, activation flow, demo record, and pricing gateway.
+- `/verify` — root verification entry that redirects QRVID lookups to `verify.qrv.network`.
+- `/issuer` — issuer portal explanation and handoff to `issuer.qrv.network`.
+- `/docs` — documentation handoff to `docs.qrv.network`.
+- `/developers` — developer portal handoff to `developers.qrv.network`.
+- `/pricing` — issuer plan pricing and checkout handoff to `store.qrv.network`.
+- `/status` — status center handoff and service directory.
+- `/store` — commerce handoff to the WordPress/WooCommerce store.
+- `/network` — full service directory with roles, hosts, and visibility.
+
+The app also preserves legacy public marketing paths such as `/protocol`, `/how-it-works`, `/registry`, `/use-cases/*`, `/book-demo`, `/about`, `/security`, `/legal`, `/privacy`, and `/terms` so existing links continue to resolve while the main experience consolidates around the command-hub routes.
+
+## Operational subdomains
+
+QRV.network links to, but does not collapse, these production services:
+
+- `verify.qrv.network` — public verification trust surface.
+- `issuer.qrv.network` — issuer SaaS app.
+- `registry.qrv.network` — canonical registry authority.
+- `api.qrv.network` — JSON API gateway.
+- `docs.qrv.network` — standards and documentation.
+- `developers.qrv.network` — SDKs and integration resources.
+- `status.qrv.network` — monitoring and incidents.
+- `admin.qrv.network` — protected internal operations.
+- `store.qrv.network` — WordPress/WooCommerce commerce.
+
+## First live activation path
+
+The command hub presents the production lifecycle as:
+
+1. Create Certificate
+2. Save Through API
+3. Store In Registry
+4. Verify Publicly
+5. Return VERIFIED
+
+The primary call-to-action order is:
+
+1. Issue Certificate
+2. Verify Demo Record
+3. View API Docs
+4. View Plans
+
+The demo QRVID is `QRV-DEMO-001`, which links to:
+
+```text
+https://verify.qrv.network/QRV-DEMO-001
+```
+
+## Issuer pricing gateway
+
+The pricing page presents these commercial entry points and routes checkout to `store.qrv.network`:
+
+- Starter Issuer — `$199/month`
+- Growth Issuer — `$499/month`
+- Professional Issuer — `$1,500/month`
+- Enterprise / Network Issuer — `$5,000+/month`
+
+## Compatibility issuer endpoints
+
+The root app keeps lightweight compatibility API endpoints for existing tooling, but public issuer pages now hand off to `issuer.qrv.network`:
 
 - `POST /api/issue` — creates a registry record through `POST /registry/create`.
 - `GET /api/records` — returns records created during this runtime.
@@ -29,6 +80,8 @@ This service is the issuer onboarding and monetization layer. It lets authorized
 
 ## Runtime endpoints
 
+Hostinger, uptime monitors, and load balancers can use:
+
 - `/ping`
 - `/health`
 - `/healthz`
@@ -36,7 +89,7 @@ This service is the issuer onboarding and monetization layer. It lets authorized
 - `/readyz`
 - `/version`
 
-The app boots without blocking on registry availability. Registry reads/writes happen inside route handlers, and readiness checks return `503` only from `/ready` or `/readyz` when the registry is unavailable.
+The root app boots without blocking on registry availability. Registry reads/writes happen inside compatibility API handlers, and the root marketing pages render without registry credentials.
 
 ## Required Hostinger environment pattern
 
@@ -44,26 +97,26 @@ The app boots without blocking on registry availability. Registry reads/writes h
 NODE_ENV=production
 APP_ENV=production
 PORT=3000
-APP_VERSION=1.1.0
+APP_VERSION=1.2.0
 TZ=UTC
 LOG_LEVEL=info
-APP_BASE_URL=https://issuer.qrv.network
+APP_BASE_URL=https://qrv.network
+QRV_PUBLIC_SITE_URL=https://qrv.network
+QRV_VERIFY_URL=https://verify.qrv.network
+QRV_ISSUER_URL=https://issuer.qrv.network
+QRV_REGISTRY_URL=https://registry.qrv.network
+QRV_API_URL=https://api.qrv.network
+QRV_DOCS_URL=https://docs.qrv.network
+QRV_DEVELOPERS_URL=https://developers.qrv.network
+QRV_STATUS_URL=https://status.qrv.network
+QRV_ADMIN_URL=https://admin.qrv.network
+QRV_STORE_URL=https://store.qrv.network
 VERIFY_BASE_URL=https://verify.qrv.network
 REGISTRY_BASE_URL=https://registry.qrv.network
 ISSUER_API_KEY=replace-with-issuer-registry-key
 RATE_LIMIT_WINDOW_MS=60000
-RATE_LIMIT_MAX=120
+RATE_LIMIT_MAX=180
 ```
-
-## Scripts
-
-- `npm run start` → `node server.js`
-- `npm run check` → `node --check server.js`
-- `npm run dev` → `NODE_ENV=development node server.js`
-- `npm run acceptance:live` → monitor-style live checks with `User-Agent: QRV-Monitor/1.0`
-# QR-V Network root site (`qrv.network`)
-
-This repository now runs the production root marketing site for **qrv.network** as a Hostinger-compatible Node/Express application.
 
 ## Hostinger compatibility
 
@@ -77,129 +130,36 @@ Use these settings in Hostinger's Node.js app configuration:
 
 The app intentionally uses a single `server.js` entry point and does not require a separate build step.
 
-## Public site routes
+## Current 503 triage for `verify.qrv.network`
 
-The root site serves real route-specific pages for:
+If the public verifier returns `503 Service Unavailable`, fix that deployment before launching new public campaigns. Check in this order:
 
-- `/`
-- `/protocol`
-- `/how-it-works`
-- `/registry`
-- `/use-cases`
-- `/use-cases/certificates`
-- `/use-cases/membership-id`
-- `/use-cases/product-authentication`
-- `/use-cases/document-verification`
-- `/use-cases/asset-records`
-- `/developers`
-- `/pricing`
-- `/book-demo`
-- `/about`
-- `/status`
-- `/security`
-- `/legal`
-- `/privacy`
-- `/terms`
+1. Confirm `qrv-verify` is assigned to `verify.qrv.network` in Hostinger.
+2. Confirm the start command is `npm start`.
+3. Confirm Hostinger sets `PORT` and the app listens on that port.
+4. Confirm `REGISTRY_BASE_URL=https://registry.qrv.network`.
+5. Confirm `https://verify.qrv.network/healthz` responds.
+6. Confirm `https://verify.qrv.network/readyz` responds.
+7. Confirm `https://verify.qrv.network/QRV-DEMO-001` loads.
 
-The first product positioning is **QR-V Verified Certificates**. Pricing content includes:
+## Scripts
 
-- Starter Issuer
-- Growth Issuer
-- Professional Issuer
-- Enterprise / Network Issuer
-- Launch Packages
-
-## Global QRVID verification redirect
-
-Every page includes a global QRVID verification form. Submitting a QRVID redirects with HTTP `303` to:
-
-```text
-https://verify.qrv.network/{QRVID}
-```
-
-The local compatibility route also supports:
-
-```text
-GET /verify?qrvid={QRVID}
-POST /verify
-```
-
-## Live Network URLs
-
-Set the public URLs in `.env` using the values from `.env.example`:
-
-- `QRV_PUBLIC_SITE_URL=https://qrv.network`
-- `QRV_VERIFY_URL=https://verify.qrv.network`
-- `QRV_REGISTRY_URL=https://registry.qrv.network`
-- `QRV_API_URL=https://api.qrv.network`
-- `QRV_ISSUER_URL=https://issuer.qrv.network`
-- `QRV_DOCS_URL=https://docs.qrv.network`
-- `QRV_DEVELOPERS_URL=https://developers.qrv.network`
-- `QRV_STATUS_URL=https://status.qrv.network`
-
-These values power the **Live Network** cards for:
-
-- `qrv.network`
-- `verify.qrv.network`
-- `registry.qrv.network`
-- `api.qrv.network`
-- `issuer.qrv.network`
-- `docs.qrv.network`
-- `developers.qrv.network`
-- `status.qrv.network`
-
-## Health and runtime endpoints
-
-Hostinger, uptime monitors, and load balancers can use:
-
-- `/health`
-- `/healthz`
-- `/ready`
-- `/readyz`
-- `/version`
-- `/ping`
+- `npm run start` → `node server.js`
+- `npm run check` → `node --check server.js`
+- `npm run build` → no-op Hostinger compatibility build
+- `npm run dev` → `NODE_ENV=development node server.js`
+- `npm run acceptance:live` → monitor-style live checks with `User-Agent: QRV-Monitor/1.0`
+- `npm run smoke:domains` → live content-type smoke checks for primary service hosts
 
 ## Local development
 
 ```bash
 npm install
 npm run check
-npm start
-```
-
-Then open `http://localhost:3000`.
-
-For a different local port:
-
-```bash
 PORT=3010 npm start
 ```
 
-## Hostinger deployment steps
-
-1. Upload or deploy the repository contents to the Hostinger Node.js application root.
-2. Confirm the application root is `./` and the startup file is `server.js`.
-3. Select Node `20.x`.
-4. Add environment variables from `.env.example` in Hostinger's environment variable panel.
-5. Run `npm install` from Hostinger or allow Hostinger to install dependencies.
-6. Start the app with `npm start`.
-7. Verify the deployment:
-   - `https://qrv.network/health`
-   - `https://qrv.network/ready`
-   - `https://qrv.network/version`
-   - `https://qrv.network/pricing`
-   - Submit a QRVID and confirm it redirects to `https://verify.qrv.network/{QRVID}`.
-
-## Compatibility notes
-
-The app keeps lightweight issuer compatibility endpoints for existing operational tooling:
-
-- `GET /issue`
-- `POST /issue`
-- `POST /api/issue`
-- `POST /api/revoke/:qrvid`
-
-These routes require registry credentials when creating or revoking live records. The public qrv.network root site does not require registry credentials to render marketing pages or health endpoints.
+Then open `http://localhost:3010`.
 
 ## Trust and legal disclaimer
 

--- a/server.js
+++ b/server.js
@@ -1,43 +1,43 @@
 require('dotenv').config();
+const crypto = require('crypto');
 const express = require('express');
 const helmet = require('helmet');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
-const crypto = require('crypto');
 
 const app = express();
 const isProduction = process.env.NODE_ENV === 'production';
 const PORT = Number(process.env.PORT || 3000);
 const VERSION = process.env.APP_VERSION || process.env.npm_package_version || '1.2.0';
 
+function publicUrl(value, fallback) {
+  return String(value || fallback).replace(/\/+$/, '');
+}
+
 const URLS = {
   site: publicUrl(process.env.QRV_PUBLIC_SITE_URL || process.env.APP_BASE_URL, 'https://qrv.network'),
   verify: publicUrl(process.env.QRV_VERIFY_URL || process.env.VERIFY_BASE_URL, 'https://verify.qrv.network'),
+  issuer: publicUrl(process.env.QRV_ISSUER_URL || process.env.APP_BASE_URL, 'https://issuer.qrv.network'),
   registry: publicUrl(process.env.QRV_REGISTRY_URL || process.env.REGISTRY_BASE_URL, 'https://registry.qrv.network'),
   api: publicUrl(process.env.QRV_API_URL || process.env.NEXT_PUBLIC_QRV_API_BASE_URL, 'https://api.qrv.network'),
-  issuer: publicUrl(process.env.QRV_ISSUER_URL, 'https://issuer.qrv.network'),
   docs: publicUrl(process.env.QRV_DOCS_URL, 'https://docs.qrv.network'),
   developers: publicUrl(process.env.QRV_DEVELOPERS_URL, 'https://developers.qrv.network'),
-  status: publicUrl(process.env.QRV_STATUS_URL, 'https://status.qrv.network')
+  status: publicUrl(process.env.QRV_STATUS_URL, 'https://status.qrv.network'),
+  admin: publicUrl(process.env.QRV_ADMIN_URL, 'https://admin.qrv.network'),
+  store: publicUrl(process.env.QRV_STORE_URL, 'https://store.qrv.network'),
+  security: publicUrl(process.env.QRV_SECURITY_URL, 'https://security.qrv.network')
 };
 
 const ISSUER_API_KEY = process.env.ISSUER_API_KEY || process.env.REGISTRY_API_KEY || '';
 const DEFAULT_ISSUER_NAME = process.env.DEFAULT_ISSUER_NAME || 'QRV Demo Issuer';
 const DEFAULT_RECORD_PREFIX = process.env.DEFAULT_RECORD_PREFIX || 'QRV-CERT';
-const RATE_LIMIT_WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS || 60 * 1000);
-const RATE_LIMIT_MAX = Number(process.env.RATE_LIMIT_MAX || 120);
+const RATE_LIMIT_WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000);
+const RATE_LIMIT_MAX = Number(process.env.RATE_LIMIT_MAX || 180);
+const DEMO_QRVID = 'QRV-DEMO-001';
 
 const issuedRecords = new Map();
 const scanCounts = new Map();
 const auditEvents = [];
-
-app.disable('x-powered-by');
-app.use(helmet({ contentSecurityPolicy: false }));
-app.use(cors());
-app.use(express.json({ limit: '1mb' }));
-app.use(express.urlencoded({ extended: true }));
-app.use(rateLimit({ windowMs: RATE_LIMIT_WINDOW_MS, max: RATE_LIMIT_MAX }));
-const DEFAULT_ISSUER_NAME = process.env.DEFAULT_ISSUER_NAME || 'QR-V Demo Issuer';
 
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
@@ -45,13 +45,40 @@ app.use(helmet({ contentSecurityPolicy: false }));
 app.use(cors({ origin: true, credentials: false }));
 app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true }));
-app.use(rateLimit({ windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000), max: Number(process.env.RATE_LIMIT_MAX || 180) }));
+app.use(rateLimit({ windowMs: RATE_LIMIT_WINDOW_MS, max: RATE_LIMIT_MAX }));
 
-function now() { return new Date().toISOString(); }
-function escapeHtml(value) { return String(value ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
-function authHeaders() { return ISSUER_API_KEY ? { authorization: `Bearer ${ISSUER_API_KEY}` } : {}; }
-function verifyUrl(qrvid) { return `${VERIFY_BASE_URL}/${encodeURIComponent(qrvid)}`; }
-function qrCodeUrl(qrvid) { return `https://api.qrserver.com/v1/create-qr-code/?size=240x240&data=${encodeURIComponent(verifyUrl(qrvid))}`; }
+function now() {
+  return new Date().toISOString();
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function cleanQrvid(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^https?:\/\/verify\.qrv\.network\//i, '')
+    .replace(/^\/+/, '');
+}
+
+function authHeaders() {
+  return ISSUER_API_KEY ? { authorization: `Bearer ${ISSUER_API_KEY}` } : {};
+}
+
+function verifyUrl(qrvid) {
+  return `${URLS.verify}/${encodeURIComponent(qrvid)}`;
+}
+
+function qrCodeUrl(qrvid) {
+  return `https://api.qrserver.com/v1/create-qr-code/?size=240x240&data=${encodeURIComponent(verifyUrl(qrvid))}`;
+}
+
 function statusLabel(value) {
   const normalized = String(value || '').toUpperCase();
   if (['VERIFIED', 'REVOKED', 'EXPIRED', 'NOT_FOUND', 'INVALID_FORMAT', 'UNAVAILABLE'].includes(normalized)) return normalized;
@@ -59,10 +86,12 @@ function statusLabel(value) {
   if (normalized === 'MISSING') return 'NOT_FOUND';
   return 'UNAVAILABLE';
 }
+
 function addAudit(eventType, details = {}) {
   auditEvents.unshift({ eventType, details, timestamp: now() });
   if (auditEvents.length > 50) auditEvents.pop();
 }
+
 function rememberRecord(record) {
   if (!record?.qrvid) return record;
   const existing = issuedRecords.get(record.qrvid) || {};
@@ -73,306 +102,178 @@ function rememberRecord(record) {
     verifyUrl: record.verifyUrl || existing.verifyUrl || verifyUrl(record.qrvid),
     qrCodeUrl: record.qrCodeUrl || existing.qrCodeUrl || qrCodeUrl(record.qrvid),
     createdAt: existing.createdAt || record.timestamp || now(),
-    updatedAt: now(),
+    updatedAt: now()
   };
   issuedRecords.set(record.qrvid, normalized);
   return normalized;
 }
+
 function getRecords() {
   return Array.from(issuedRecords.values()).sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)));
 }
-function recordCard(record) {
-  return `<article class="record-card"><div><p class="eyebrow">${escapeHtml(record.recordType || record.type || 'certificate')}</p><h3>${escapeHtml(record.title || record.payload?.title || record.qrvid)}</h3><p class="mono">${escapeHtml(record.qrvid)}</p><p>${escapeHtml(record.issuer || DEFAULT_ISSUER_NAME)} · ${escapeHtml(record.owner || record.subject || 'Issued subject')}</p></div><div><span class="pill ${escapeHtml(statusLabel(record.status).toLowerCase())}">${escapeHtml(statusLabel(record.status))}</span><p class="small">Scans: ${Number(scanCounts.get(record.qrvid) || record.scans || 0)}</p><p><a class="btn small-btn" href="${escapeHtml(record.verifyUrl || verifyUrl(record.qrvid))}">Verify</a> <a class="btn alt small-btn" href="/revoke?qrvid=${encodeURIComponent(record.qrvid)}">Revoke</a></p></div></article>`;
-}
-function pageHeader(title, subtitle) {
-  return `<section class="hero"><div class="eyebrow">Issuer Portal</div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(subtitle)}</p><p><a class="btn" href="/records/new">Create Record</a> <a class="btn alt" href="/records">View Records</a></p></section>`;
-}
-function navLink(path, label) { return `<a href="${path}">${label}</a>`; }
 
-function layout(body, title = 'QR-V Issuer Portal') {
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(title)}</title><style>:root{--bg:#061126;--panel:#101f42;--line:#2d477a;--gold:#f2d06b;--cyan:#62cbff;--text:#eef4ff;--muted:#b7c6e6;--green:#22c55e;--red:#ef4444;--orange:#f59e0b}*{box-sizing:border-box}body{margin:0;font-family:Inter,Arial,sans-serif;background:radial-gradient(circle at top,#14366f,#061126 52%,#030711);color:var(--text)}.wrap{max-width:1180px;margin:0 auto;padding:30px 20px}.nav{display:flex;justify-content:space-between;gap:16px;align-items:center}.brand{font-weight:900;letter-spacing:.08em}.nav a{color:#dbeafe;text-decoration:none;margin-left:14px}.hero,.card{background:rgba(16,31,66,.9);border:1px solid var(--line);border-radius:24px;padding:26px;margin-top:24px}.record-card{display:flex;justify-content:space-between;gap:20px;align-items:center;background:rgba(8,23,53,.75);border:1px solid var(--line);border-radius:18px;padding:18px;margin:14px 0}h1{font-size:clamp(38px,7vw,72px);line-height:1;margin:10px 0}p,li{color:var(--muted);font-size:17px;line-height:1.6}.small{font-size:14px}.eyebrow{color:var(--gold);font-size:13px;text-transform:uppercase;letter-spacing:.14em;font-weight:900}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}.two{grid-template-columns:repeat(2,1fr)}.btn,button{display:inline-block;border:0;border-radius:999px;background:var(--gold);color:#071126;font-weight:900;padding:13px 18px;text-decoration:none;cursor:pointer}.small-btn{padding:9px 13px;font-size:14px}.btn.alt{background:transparent;border:1px solid var(--line);color:#fff}input,select,textarea{width:100%;padding:14px;border-radius:14px;border:1px solid #3a5288;background:#081735;color:#fff;font-size:16px}label{display:block;margin:12px 0 6px;font-weight:800}.mono{font-family:ui-monospace,Menlo,monospace;color:#dbeafe;word-break:break-word}.success{border-left:4px solid var(--green)}.error{border-left:4px solid var(--red)}.pill{display:inline-block;border-radius:999px;padding:8px 12px;font-weight:900;font-size:12px;background:#1f3b6d;color:#dbeafe}.pill.verified{background:rgba(34,197,94,.18);color:#86efac}.pill.revoked,.pill.expired{background:rgba(245,158,11,.18);color:#fcd34d}.pill.unavailable{background:rgba(239,68,68,.18);color:#fecaca}.stat{font-size:34px;color:#fff;font-weight:900;margin:0}.qr{background:#fff;border-radius:16px;padding:12px;max-width:264px}.footer{margin:30px 0;color:var(--muted)}@media(max-width:800px){.grid,.two{grid-template-columns:1fr}.nav,.record-card{align-items:flex-start;flex-direction:column}.nav a{margin:0 10px 0 0}}</style></head><body><div class="wrap"><nav class="nav"><div class="brand">QR-V™ ISSUER</div><div>${navLink('/dashboard','Dashboard')}${navLink('/records','Records')}${navLink('/issue','Issue')}${navLink('/revoke','Revoke')}${navLink('/api-keys','API Keys')}${navLink('/billing','Billing')}${navLink('/settings','Settings')}</div></nav>${body}<p class="footer">Registry: <span class="mono">${escapeHtml(REGISTRY_BASE_URL)}</span> · Verify: <span class="mono">${escapeHtml(VERIFY_BASE_URL)}</span></p></div></body></html>`;
-function publicUrl(value, fallback) { return String(value || fallback).replace(/\/+$/, ''); }
-function cleanQrvid(value) { return String(value || '').trim().replace(/^https?:\/\/verify\.qrv\.network\//i, '').replace(/^\/+/, ''); }
-
-const networkCards = [
-  { host: 'qrv.network', label: 'Root site', url: URLS.site, body: 'Product, trust, pricing, and route-specific public pages for the QR-V Network.' },
-  { host: 'verify.qrv.network', label: 'Verifier', url: URLS.verify, body: 'Public QRVID lookup destination for recipients, auditors, and relying parties.' },
-  { host: 'registry.qrv.network', label: 'Registry', url: URLS.registry, body: 'Record authority, lifecycle state, revocation status, and registry API surface.' },
-  { host: 'api.qrv.network', label: 'API', url: URLS.api, body: 'Programmatic QRVID issuance, verification, status, webhook, and network endpoints.' },
-  { host: 'issuer.qrv.network', label: 'Issuer', url: URLS.issuer, body: 'Issuer portal for creating QR-V Verified Certificates and managed records.' },
-  { host: 'docs.qrv.network', label: 'Docs', url: URLS.docs, body: 'Implementation guides, API references, verification patterns, and examples.' },
-  { host: 'developers.qrv.network', label: 'Developers', url: URLS.developers, body: 'Developer onboarding, SDK direction, sandboxes, and integration resources.' },
-  { host: 'status.qrv.network', label: 'Status', url: URLS.status, body: 'Operational availability, maintenance notices, and incident communications.' }
-];
-
-const useCases = [
-  { slug: '/use-cases/certificates', title: 'Certificates', short: 'Make educational, training, course, award, and compliance certificates instantly verifiable.', icon: '◈' },
-  { slug: '/use-cases/membership-id', title: 'Membership ID', short: 'Give members a QRVID-backed proof that can be checked without exposing private account data.', icon: '◆' },
-  { slug: '/use-cases/product-authentication', title: 'Product Authentication', short: 'Attach verification to product labels, lots, serials, limited editions, and after-market authenticity checks.', icon: '◇' },
-  { slug: '/use-cases/document-verification', title: 'Document Verification', short: 'Bind documents to a registry record so recipients can confirm status and issuer identity.', icon: '▣' },
-  { slug: '/use-cases/asset-records', title: 'Asset Records', short: 'Publish verifiable status records for equipment, property, collectibles, and controlled assets.', icon: '▤' }
-];
-
-const pricingPlans = [
-  { name: 'Starter Issuer', price: '$99/mo', audience: 'Small certificate issuers and pilots', features: ['Issue QR-V Verified Certificates', 'Hosted verification links', 'Basic issuer profile', 'Email support'] },
-  { name: 'Growth Issuer', price: '$299/mo', audience: 'Growing teams with recurring issuance', features: ['Higher monthly issuance capacity', 'Batch-ready workflows', 'Registry status controls', 'Priority onboarding'] },
-  { name: 'Professional Issuer', price: '$799/mo', audience: 'Operational teams and trust-sensitive programs', features: ['Advanced issuer controls', 'Custom verification branding options', 'Revocation and status workflows', 'Integration planning'] },
-  { name: 'Enterprise / Network Issuer', price: 'Custom', audience: 'Institutions, networks, and high-volume deployments', features: ['Dedicated launch architecture', 'Custom contracts and compliance review', 'API and portal alignment', 'Support and SLA options'] }
-];
-
-function verificationForm() {
-  return `<form class="verify-form" method="post" action="/verify" aria-label="Verify a QRVID"><label for="qrvid">Verify any QRVID</label><div class="verify-row"><input id="qrvid" name="qrvid" inputmode="latin" autocomplete="off" placeholder="QRV-CERT-000001" required><button type="submit">Verify</button></div><small>Redirects to ${escapeHtml(URLS.verify)}/{QRVID}</small></form>`;
+function requestJson(url, options = {}) {
+  return fetch(url, options).then(async (response) => {
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(body.error || body.message || `Request failed: ${response.status}`);
+    return body;
+  });
 }
 
-function liveNetworkSection() {
-  return `<section class="section" id="network"><div class="section-head"><p class="eyebrow">Live Network</p><h2>One trust network, purpose-built subdomains.</h2><p>QR-V separates verification, registry, issuer, API, documentation, developer, and status responsibilities across clear production endpoints.</p></div><div class="grid four">${networkCards.map(card => `<a class="network-card" href="${escapeHtml(card.url)}"><span>${escapeHtml(card.label)}</span><strong>${escapeHtml(card.host)}</strong><p>${escapeHtml(card.body)}</p></a>`).join('')}</div></section>`;
+function normalizeRegistryRecord(qrvid, data, fallback = {}) {
+  const record = data.record || data.result || data;
+  const normalizedQrvid = record.qrvid || record.id || qrvid;
+  return rememberRecord({
+    ...fallback,
+    ...record,
+    qrvid: normalizedQrvid,
+    status: statusLabel(record.status || data.status || fallback.status || 'VERIFIED'),
+    verifyUrl: record.verifyUrl || verifyUrl(normalizedQrvid),
+    qrCodeUrl: record.qrCodeUrl || qrCodeUrl(normalizedQrvid),
+    timestamp: record.timestamp || data.timestamp || now()
+  });
 }
 
-function disclaimerBlock() {
-  return `<section class="disclaimer"><strong>Trust and legal notice.</strong> QR-V provides registry-backed verification infrastructure and public status pages. QR-V does not automatically certify the truth, legality, ownership, identity, regulatory standing, or fitness of issuer-supplied content. Relying parties should review issuer identity, record scope, jurisdiction, applicable law, and the current verification status before making decisions.</section>`;
-}
-
-function layout({ title = 'QR-V Network', description = 'QR-V Network turns QR codes into registry-backed verification records.', path = '/', body }) {
-  const canonical = `${URLS.site}${path === '/' ? '' : path}`;
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>${escapeHtml(title)}</title>
-<meta name="description" content="${escapeHtml(description)}">
-<link rel="canonical" href="${escapeHtml(canonical)}">
-<style>
-:root{--bg:#050914;--panel:#0d1730;--panel2:#101f42;--line:#263a67;--gold:#f2d06b;--cyan:#66d9ff;--text:#f3f7ff;--muted:#b9c8e8;--green:#22c55e;--red:#ef4444;--shadow:0 30px 90px rgba(0,0,0,.36)}*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:radial-gradient(circle at 15% 0,#143c76 0,#08142c 32%,#050914 72%);color:var(--text)}a{color:inherit}.wrap{max-width:1180px;margin:0 auto;padding:0 22px}.top{position:sticky;top:0;z-index:10;background:rgba(5,9,20,.82);backdrop-filter:blur(16px);border-bottom:1px solid rgba(255,255,255,.08)}.nav{display:flex;align-items:center;justify-content:space-between;gap:20px;padding:16px 0}.brand{display:flex;align-items:center;gap:10px;text-decoration:none;font-weight:950;letter-spacing:.06em}.mark{display:grid;place-items:center;width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,var(--gold),#fff1a8);color:#061126;box-shadow:0 0 40px rgba(242,208,107,.25)}.links{display:flex;gap:16px;align-items:center;flex-wrap:wrap}.links a{text-decoration:none;color:#dbeafe;font-weight:750;font-size:14px}.links a:hover{color:#fff}.hero{padding:74px 0 36px}.hero-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:stretch}.hero-card,.section,.card,.network-card,.disclaimer{background:linear-gradient(180deg,rgba(16,31,66,.94),rgba(8,18,39,.92));border:1px solid var(--line);border-radius:28px;box-shadow:var(--shadow)}.hero-card{padding:42px}.eyebrow{margin:0 0 10px;color:var(--gold);font-size:13px;text-transform:uppercase;letter-spacing:.16em;font-weight:950}h1{font-size:clamp(42px,7vw,76px);line-height:.95;margin:10px 0 18px;letter-spacing:-.055em}h2{font-size:clamp(30px,4vw,48px);line-height:1.05;margin:0 0 14px;letter-spacing:-.035em}h3{font-size:24px;margin:0 0 10px}p,li{color:var(--muted);font-size:17px;line-height:1.65}.lead{font-size:21px;color:#deebff}.actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:24px}.btn,button{display:inline-flex;align-items:center;justify-content:center;border:0;border-radius:999px;background:var(--gold);color:#061126;font-weight:950;padding:13px 18px;text-decoration:none;cursor:pointer;min-height:46px}.btn.alt{background:transparent;border:1px solid var(--line);color:#fff}.btn.dark{background:#10244c;color:#fff;border:1px solid #37568e}.verify-panel{padding:26px}.verify-form{display:grid;gap:10px}.verify-row{display:grid;grid-template-columns:1fr auto;gap:10px}.verify-form label,label{font-weight:900;color:#fff}.verify-form small{color:#9fb1d6}input,textarea{width:100%;padding:14px 15px;border-radius:16px;border:1px solid #3a5288;background:#081735;color:#fff;font-size:16px;outline:none}input:focus,textarea:focus{border-color:var(--cyan);box-shadow:0 0 0 4px rgba(102,217,255,.12)}.section{margin:24px 0;padding:32px}.section-head{max-width:780px}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:18px}.grid.two{grid-template-columns:repeat(2,1fr)}.grid.four{grid-template-columns:repeat(4,1fr)}.card{padding:24px}.card .icon{font-size:30px;color:var(--gold)}.network-card{padding:19px;text-decoration:none;transition:transform .16s,border-color .16s}.network-card:hover{transform:translateY(-3px);border-color:var(--cyan)}.network-card span{display:inline-block;color:var(--gold);font-size:12px;text-transform:uppercase;letter-spacing:.12em;font-weight:950;margin-bottom:8px}.network-card strong{display:block;font-size:18px;word-break:break-word}.network-card p{font-size:14px;margin-bottom:0}.pill-list{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}.pill{border:1px solid var(--line);border-radius:999px;padding:9px 12px;color:#dbeafe;background:rgba(255,255,255,.04);font-weight:800}.quote{border-left:4px solid var(--gold);padding-left:18px;color:#e8f1ff}.disclaimer{padding:20px;margin:24px 0;color:#b9c8e8}.footer{padding:34px 0 60px;color:#9fb1d6}.footer-grid{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;border-top:1px solid rgba(255,255,255,.1);padding-top:24px}.footer a{color:#c9d8f5;text-decoration:none;margin-right:14px}.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-word}.status-ok{color:var(--green);font-weight:950}.status-warn{color:var(--gold);font-weight:950}.route-title{padding:54px 0 6px}@media(max-width:980px){.hero-grid,.grid,.grid.two,.grid.four{grid-template-columns:1fr}.links{display:none}.hero{padding-top:42px}.hero-card{padding:28px}.verify-row{grid-template-columns:1fr}.section{padding:24px}}
-</style>
-</head>
-<body>
-<header class="top"><div class="wrap"><nav class="nav"><a class="brand" href="/"><span class="mark">QV</span><span>QR-V Network</span></a><div class="links"><a href="/protocol">Protocol</a><a href="/how-it-works">How it works</a><a href="/registry">Registry</a><a href="/use-cases">Use cases</a><a href="/developers">Developers</a><a href="/pricing">Pricing</a><a href="/book-demo">Book demo</a></div></nav></div></header>
-<main class="wrap">${body}${disclaimerBlock()}</main>
-<footer class="wrap footer"><div class="footer-grid"><div><strong>QR-V Network</strong><p>Registry-backed QRVID verification for certificates, IDs, products, documents, and asset records.</p></div><div><a href="/security">Security</a><a href="/legal">Legal</a><a href="/privacy">Privacy</a><a href="/terms">Terms</a><a href="/status">Status</a></div></div></footer>
-</body></html>`;
-}
-
-function sendPage(res, page) { res.type('html').send(layout(page)); }
-
-function homePage() {
-  return { path: '/', title: 'QR-V Network | Registry-backed QRVID verification', description: 'The production root site for qrv.network and QR-V Verified Certificates.', body: `<section class="hero"><div class="hero-grid"><div class="hero-card"><p class="eyebrow">QR-V Verified Certificates</p><h1>Turn every certificate into a live verification record.</h1><p class="lead">QR-V gives issuers a registry-backed QRVID that lets recipients, employers, auditors, and customers verify status at the moment of trust.</p><div class="actions"><a class="btn" href="/book-demo">Book a demo</a><a class="btn alt" href="/protocol">Explore the protocol</a></div><div class="pill-list"><span class="pill">Issue</span><span class="pill">Verify</span><span class="pill">Revoke</span><span class="pill">Audit</span></div></div><div class="hero-card verify-panel">${verificationForm()}<hr style="border-color:rgba(255,255,255,.1);margin:24px 0"><h3>First product positioning</h3><p><strong>QR-V Verified Certificates</strong> are the first commercial QR-V product: a verification layer for credentials that need clear issuer identity, current status, and durable lookup.</p></div></div></section><section class="section"><p class="eyebrow">What QR-V does</p><h2>QR codes are easy to copy. QRVIDs are records you can verify.</h2><div class="grid"><div class="card"><h3>Registry-backed</h3><p>Each QRVID resolves to a record with issuer context, record type, lifecycle status, and verification metadata.</p></div><div class="card"><h3>Route-specific</h3><p>Separate product, protocol, registry, use case, developer, pricing, status, security, and legal pages support production discovery.</p></div><div class="card"><h3>Trust-aware</h3><p>Public status and legal disclaimers clarify what the network proves, what issuers attest, and what relying parties must review.</p></div></div></section>${liveNetworkSection()}` };
-}
-
-function standardPage({ path, title, eyebrow, heading, lead, cards = [], extra = '' }) {
-  return { path, title: `${title} | QR-V Network`, description: lead, body: `<section class="route-title"><p class="eyebrow">${escapeHtml(eyebrow)}</p><h1>${escapeHtml(heading)}</h1><p class="lead">${escapeHtml(lead)}</p><div class="actions"><a class="btn" href="/book-demo">Book a demo</a><a class="btn alt" href="/pricing">View pricing</a></div></section><section class="section"><div class="grid ${cards.length === 2 ? 'two' : ''}">${cards.map(card => `<div class="card"><div class="icon">${card.icon || '•'}</div><h3>${escapeHtml(card.title)}</h3><p>${escapeHtml(card.body)}</p></div>`).join('')}</div></section>${extra}` };
-}
-
-function pricingPage() {
-  return { path: '/pricing', title: 'Pricing | QR-V Network', description: 'QR-V pricing for Starter, Growth, Professional, Enterprise, and Launch Packages.', body: `<section class="route-title"><p class="eyebrow">Pricing</p><h1>Issuer plans for every stage of verification.</h1><p class="lead">Start with QR-V Verified Certificates, then expand into higher-volume issuance, integrations, and network-level deployments.</p></section><section class="section"><div class="grid four">${pricingPlans.map(plan => `<div class="card"><p class="eyebrow">${escapeHtml(plan.audience)}</p><h3>${escapeHtml(plan.name)}</h3><h2>${escapeHtml(plan.price)}</h2><ul>${plan.features.map(feature => `<li>${escapeHtml(feature)}</li>`).join('')}</ul><a class="btn" href="/book-demo">Discuss plan</a></div>`).join('')}</div></section><section class="section"><p class="eyebrow">Launch Packages</p><h2>Launch with the records, pages, and rollout support already mapped.</h2><div class="grid"><div class="card"><h3>Certificate launch</h3><p>Issuer profile setup, first QR-V Verified Certificate workflow, pilot records, and verification-page readiness.</p></div><div class="card"><h3>Integration launch</h3><p>API route planning, issuance workflow mapping, registry status model, and developer handoff.</p></div><div class="card"><h3>Network launch</h3><p>Multi-issuer program design, legal review support, production acceptance checklist, and operational runbook.</p></div></div></section>` };
-}
-
-function useCasesPage() {
-  return { path: '/use-cases', title: 'Use Cases | QR-V Network', description: 'QR-V use cases for certificates, membership IDs, product authentication, document verification, and asset records.', body: `<section class="route-title"><p class="eyebrow">Use cases</p><h1>Verification patterns for trust-sensitive records.</h1><p class="lead">QR-V works when a recipient needs to know whether a QR code points to a current registry-backed record from an accountable issuer.</p></section><section class="section"><div class="grid">${useCases.map(item => `<a class="card" href="${item.slug}" style="text-decoration:none"><div class="icon">${item.icon}</div><h3>${escapeHtml(item.title)}</h3><p>${escapeHtml(item.short)}</p></a>`).join('')}</div></section>` };
-}
-
-function useCaseDetail(item, body) {
-  return standardPage({ path: item.slug, title: item.title, eyebrow: 'Use case', heading: `QR-V for ${item.title}`, lead: item.short, cards: [
-    { title: 'Record binding', body: 'Bind a public QRVID to issuer-supplied details, status, verification context, and a durable lookup URL.', icon: item.icon },
-    { title: 'Relying-party check', body: 'Give viewers a simple path to verify status before accepting a credential, product claim, document, ID, or asset record.', icon: '✓' },
-    { title: 'Lifecycle status', body: 'Support active, revoked, replaced, expired, or superseded states depending on issuer policy and product scope.', icon: '↻' }
-  ], extra: `<section class="section"><h2>Production fit</h2><p>${escapeHtml(body)}</p>${verificationForm()}</section>` });
-}
-
-const pages = new Map();
-function add(path, factory) { pages.set(path, factory); }
-
-add('/', homePage);
-add('/protocol', () => standardPage({ path: '/protocol', title: 'Protocol', eyebrow: 'Protocol', heading: 'A practical protocol for QRVID verification.', lead: 'QR-V defines how issuers create records, how registry status is exposed, and how relying parties verify what a QR code claims.', cards: [
-  { title: 'QRVID namespace', body: 'A QRVID is a human-readable identifier that resolves to a verification URL and registry-backed status.', icon: 'ID' },
-  { title: 'Issuer attestation', body: 'Issuers publish record details and accept responsibility for the claims they put into the registry.', icon: '✦' },
-  { title: 'Verifier response', body: 'Verification pages surface current state, issuer context, and trust notices in a consistent format.', icon: '↗' }
-], extra: liveNetworkSection() }));
-add('/how-it-works', () => standardPage({ path: '/how-it-works', title: 'How it works', eyebrow: 'Workflow', heading: 'Issue, attach, scan, verify, and manage.', lead: 'QR-V is designed for simple operational adoption: create a record, attach the QRVID, and let recipients verify status online.', cards: [
-  { title: '1. Issuer creates', body: 'The issuer creates a QR-V Verified Certificate or other record with approved metadata.', icon: '1' },
-  { title: '2. QRVID attaches', body: 'The QRVID appears on a PDF, badge, label, product, document, or asset page.', icon: '2' },
-  { title: '3. Viewer verifies', body: 'A scan opens verify.qrv.network/{QRVID}, where current status and context are displayed.', icon: '3' },
-  { title: '4. Issuer manages', body: 'Issuers can revoke, replace, or update records according to their policy and plan.', icon: '4' }
-] }));
-add('/registry', () => standardPage({ path: '/registry', title: 'Registry', eyebrow: 'Registry', heading: 'The registry is the source of verification status.', lead: 'The QR-V registry supports record creation, public lookup, lifecycle state, revocation, and audit-oriented metadata.', cards: [
-  { title: 'Lookup', body: 'Public verification can resolve a QRVID to the registry status needed for a relying-party decision.', icon: '⌕' },
-  { title: 'Lifecycle', body: 'Records can be active, revoked, expired, replaced, or otherwise marked under issuer policy.', icon: '◷' },
-  { title: 'Audit trail', body: 'Registry metadata helps explain when a record was issued, by whom, and what status it currently has.', icon: '▥' }
-], extra: `<section class="section"><h2>Registry endpoint</h2><p class="mono">${escapeHtml(URLS.registry)}</p><a class="btn" href="${escapeHtml(URLS.registry)}">Open registry</a></section>` }));
-add('/use-cases', useCasesPage);
-for (const item of useCases) {
-  const copy = {
-    '/use-cases/certificates': 'Certificate programs benefit from visible issuer identity, recipient-friendly lookup, revocation support, and verification pages suitable for employers, auditors, and reviewers.',
-    '/use-cases/membership-id': 'Membership IDs can be checked at doors, online workflows, support desks, partner locations, or events without relying only on a static printed badge.',
-    '/use-cases/product-authentication': 'Products can carry QRVIDs that support authenticity checks, lot context, serial records, warranty confidence, and customer-facing verification journeys.',
-    '/use-cases/document-verification': 'Documents can include a verification URL that confirms whether the issuer still recognizes the document as current, valid, replaced, or revoked.',
-    '/use-cases/asset-records': 'Asset records can expose controlled public verification for equipment, collectibles, property, or internal assets that need durable status checks.'
-  }[item.slug];
-  add(item.slug, () => useCaseDetail(item, copy));
-}
-add('/developers', () => standardPage({ path: '/developers', title: 'Developers', eyebrow: 'Developers', heading: 'Build issuance and verification into your workflow.', lead: 'Developers can integrate with QR-V API endpoints, link to public verification, and design issuer workflows around record lifecycle states.', cards: [
-  { title: 'API-first', body: 'Use api.qrv.network for programmatic issuance, verification, and operational integrations as plans mature.', icon: '{ }' },
-  { title: 'Verification URLs', body: 'Every QRVID can route to verify.qrv.network/{QRVID}, making linking and QR generation simple.', icon: '/' },
-  { title: 'Docs and status', body: 'Use docs, developer resources, and status pages to plan reliable production rollouts.', icon: '⌘' }
-], extra: `<section class="section"><h2>Developer endpoints</h2><p class="mono">API: ${escapeHtml(URLS.api)}</p><p class="mono">Docs: ${escapeHtml(URLS.docs)}</p><p class="mono">Developers: ${escapeHtml(URLS.developers)}</p></section>` }));
-add('/pricing', pricingPage);
-add('/book-demo', () => ({ path: '/book-demo', title: 'Book a Demo | QR-V Network', description: 'Book a QR-V demo for verified certificates and issuer workflows.', body: `<section class="route-title"><p class="eyebrow">Book demo</p><h1>Plan your first QR-V Verified Certificate launch.</h1><p class="lead">Tell us what you issue, who verifies it, and what trust decision the verification page must support.</p></section><section class="section"><div class="grid two"><div class="card"><h3>Demo agenda</h3><ul><li>Issuer and recipient workflow mapping</li><li>Certificate or record type selection</li><li>Verification-page content review</li><li>Pricing and launch package fit</li></ul></div><div class="card"><h3>Contact</h3><p>Use your existing QR-V sales/contact channel or connect through the issuer portal.</p><p><a class="btn" href="${escapeHtml(URLS.issuer)}">Open issuer portal</a></p></div></div></section>` }));
-add('/about', () => standardPage({ path: '/about', title: 'About', eyebrow: 'About', heading: 'QR-V is verification infrastructure for real-world records.', lead: 'The network exists to make scanned credentials, IDs, products, documents, and assets easier to validate and easier to govern.', cards: [
-  { title: 'Mission', body: 'Reduce uncertainty around QR-based claims by connecting every code to live status and issuer context.', icon: '★' },
-  { title: 'Focus', body: 'Start with QR-V Verified Certificates, then extend the same pattern to other record categories.', icon: '→' },
-  { title: 'Principle', body: 'Be clear about what QR-V verifies and what remains an issuer, legal, or relying-party responsibility.', icon: '!' }
-] }));
-add('/status', () => ({ path: '/status', title: 'Status | QR-V Network', description: 'QR-V network status routes and health checks.', body: `<section class="route-title"><p class="eyebrow">Status</p><h1>Network status and runtime checks.</h1><p class="lead">Use the public status page for incidents and the local health endpoints for deployment monitoring.</p></section><section class="section"><div class="grid"><div class="card"><h3>Public status</h3><p class="status-ok">Configured</p><p class="mono">${escapeHtml(URLS.status)}</p><a class="btn" href="${escapeHtml(URLS.status)}">Open status</a></div><div class="card"><h3>Health endpoints</h3><p class="mono">/health /healthz /ready /readyz /version /ping</p></div><div class="card"><h3>Runtime</h3><p class="mono">Node 20.x compatible Express server.js</p><p class="mono">Version ${escapeHtml(VERSION)}</p></div></div></section>${liveNetworkSection()}` }));
-add('/security', () => standardPage({ path: '/security', title: 'Security', eyebrow: 'Security', heading: 'Security is built around clear trust boundaries.', lead: 'QR-V separates issuer claims, registry status, public verification, operational monitoring, and relying-party responsibility.', cards: [
-  { title: 'No hidden import wrappers', body: 'The app starts directly from server.js for predictable Hostinger deployment and Node 20.x compatibility.', icon: '✓' },
-  { title: 'Rate limited', body: 'Runtime requests are rate limited to reduce abuse against the marketing site and verification redirect form.', icon: '⏱' },
-  { title: 'Scoped redirects', body: 'The QRVID form only redirects to the configured verification host using the submitted identifier as a path segment.', icon: '↪' }
-] }));
-add('/legal', () => standardPage({ path: '/legal', title: 'Legal', eyebrow: 'Legal', heading: 'Legal and trust disclaimers.', lead: 'QR-V is infrastructure. Issuers remain responsible for issuer-supplied content, authority, compliance, and record claims.', cards: [
-  { title: 'Issuer responsibility', body: 'Issuers are responsible for the accuracy, authorization, and compliance of records they publish.', icon: '§' },
-  { title: 'No universal endorsement', body: 'A QR-V status page does not mean QR-V endorses the issuer, recipient, product, asset, or underlying claim.', icon: '!' },
-  { title: 'Relying-party review', body: 'Relying parties should check current status, scope, issuer identity, and applicable laws before acting.', icon: '✓' }
-] }));
-add('/privacy', () => standardPage({ path: '/privacy', title: 'Privacy', eyebrow: 'Privacy', heading: 'Privacy notice for the public QR-V site.', lead: 'The public site is designed to minimize data collection while supporting verification, operations, analytics, security, and support.', cards: [
-  { title: 'Verification data', body: 'Public verification may show issuer-provided record details necessary for relying-party review.', icon: '◌' },
-  { title: 'Operational data', body: 'Logs may include IP address, user agent, route, timestamp, and security signals needed to operate the service.', icon: '⌁' },
-  { title: 'Issuer data', body: 'Issuer portal and API data are governed by applicable agreements, product settings, and jurisdictional requirements.', icon: '▣' }
-] }));
-add('/terms', () => standardPage({ path: '/terms', title: 'Terms', eyebrow: 'Terms', heading: 'Terms summary for QR-V Network use.', lead: 'Use of QR-V is subject to applicable agreements, acceptable-use requirements, issuer responsibilities, and verification disclaimers.', cards: [
-  { title: 'Acceptable use', body: 'Do not use QR-V for unlawful, deceptive, harmful, infringing, or unauthorized records.', icon: '✓' },
-  { title: 'Availability', body: 'Network availability can vary due to maintenance, incidents, third-party services, or deployment conditions.', icon: '◷' },
-  { title: 'Changes', body: 'Product features, pricing, routing, and terms may evolve as the network matures.', icon: '↻' }
-] }));
-
-async function requestJson(url, options = {}) {
-  const response = await fetch(url, options);
-  const body = await response.json().catch(() => ({}));
-  if (!response.ok) throw new Error(body.error || body.message || `Request failed: ${response.status}`);
-  return body;
-}
 async function createRegistryRecord({ type, issuer, owner, title, expiresAt, payload }) {
-  const localQrvid = `${DEFAULT_RECORD_PREFIX}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
   const body = { type, recordType: type, issuer, owner, title, expiresAt, payload: { title, ...payload } };
-  const result = await requestJson(`${REGISTRY_BASE_URL}/registry/create`, {
-async function createRegistryRecord({ type, issuer, owner, payload }) {
-  const response = await fetch(`${URLS.registry}/registry/create`, {
+  const result = await requestJson(`${URLS.registry}/registry/create`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...authHeaders() },
     body: JSON.stringify(body)
   });
-  const qrvid = result.qrvid || result.id || localQrvid;
-  return rememberRecord({ ...result, qrvid, issuer, owner, title, recordType: type, type, expiresAt, payload: body.payload, status: result.status || 'VERIFIED' });
+  const qrvid = result.qrvid || result.id || `${DEFAULT_RECORD_PREFIX}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+  return normalizeRegistryRecord(qrvid, result, body);
 }
+
+async function fetchRegistryRecord(qrvid) {
+  const result = await requestJson(`${URLS.registry}/registry/${encodeURIComponent(qrvid)}`);
+  return normalizeRegistryRecord(qrvid, result);
+}
+
 async function revokeRegistryRecord(qrvid, reason) {
-  const result = await requestJson(`${REGISTRY_BASE_URL}/registry/${encodeURIComponent(qrvid)}/revoke`, {
-  const response = await fetch(`${URLS.registry}/registry/${encodeURIComponent(qrvid)}/revoke`, {
+  const result = await requestJson(`${URLS.registry}/registry/${encodeURIComponent(qrvid)}/revoke`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ reason })
   });
-  const record = rememberRecord({ ...(issuedRecords.get(qrvid) || {}), ...result, qrvid, status: 'REVOKED', revokedAt: now(), revokeReason: reason });
+  const record = normalizeRegistryRecord(qrvid, result, { status: 'REVOKED' });
   addAudit('record.revoked', { qrvid, reason });
   return record;
 }
-async function fetchRegistryRecord(qrvid) {
-  const result = await requestJson(`${REGISTRY_BASE_URL}/registry/${encodeURIComponent(qrvid)}`, { headers: { accept: 'application/json' } });
-  return rememberRecord({ ...result, qrvid: result.qrvid || qrvid });
+
+function pageShell({ title = 'QRV.network', description = 'QR-V Network command hub for verification services.', body = '' }) {
+  const nav = [
+    ['/', 'Home'],
+    ['/verify', 'Verify'],
+    ['/issuer', 'Issuer'],
+    ['/docs', 'Docs'],
+    ['/developers', 'Developers'],
+    ['/pricing', 'Pricing'],
+    ['/status', 'Status'],
+    ['/store', 'Store'],
+    ['/network', 'Network']
+  ];
+
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="${escapeHtml(description)}"><title>${escapeHtml(title)}</title><style>:root{--bg:#071126;--panel:#101f42;--panel2:#0b1833;--line:#2d477a;--gold:#f2d06b;--cyan:#62cbff;--text:#eef4ff;--muted:#b7c6e6;--green:#22c55e;--red:#ef4444;--orange:#f59e0b}*{box-sizing:border-box}body{margin:0;font-family:Inter,Arial,sans-serif;background:radial-gradient(circle at top,#173d7a,#071126 48%,#030711);color:var(--text)}a{color:#dbeafe}.wrap{max-width:1180px;margin:0 auto;padding:28px 20px}.nav{display:flex;justify-content:space-between;align-items:center;gap:18px}.brand{font-weight:950;letter-spacing:.09em;text-decoration:none}.links{display:flex;flex-wrap:wrap;gap:12px}.links a{text-decoration:none;color:#dbeafe;font-weight:800;font-size:14px}.hero,.section,.card{background:rgba(16,31,66,.86);border:1px solid var(--line);border-radius:26px}.hero{padding:42px;margin-top:28px}.section{padding:28px;margin-top:22px}.card{background:rgba(8,23,53,.68);padding:22px}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}.grid.two{grid-template-columns:repeat(2,1fr)}.grid.four{grid-template-columns:repeat(4,1fr)}h1{font-size:clamp(42px,7vw,82px);line-height:.98;margin:10px 0 16px}h2{font-size:clamp(28px,4vw,46px);line-height:1;margin:0 0 16px}h3{margin:0 0 10px;font-size:21px}p,li{color:var(--muted);font-size:17px;line-height:1.6}.lead{font-size:21px;max-width:850px}.eyebrow{color:var(--gold);font-size:13px;text-transform:uppercase;letter-spacing:.16em;font-weight:950}.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#dbeafe;word-break:break-word}.btn,button{display:inline-block;border:0;border-radius:999px;background:var(--gold);color:#071126;font-weight:950;padding:13px 18px;text-decoration:none;cursor:pointer;margin:4px 8px 4px 0}.btn.alt{background:transparent;border:1px solid var(--line);color:#fff}.btn.blue{background:var(--cyan);color:#061126}.pill{display:inline-block;border-radius:999px;padding:7px 11px;font-weight:900;font-size:12px;background:#1f3b6d;color:#dbeafe}.pill.live{background:rgba(34,197,94,.18);color:#86efac}.pill.private{background:rgba(245,158,11,.18);color:#fcd34d}.steps{counter-reset:step;display:grid;grid-template-columns:repeat(5,1fr);gap:12px}.step{position:relative;background:rgba(8,23,53,.72);border:1px solid var(--line);border-radius:20px;padding:18px}.step:before{counter-increment:step;content:counter(step);display:inline-grid;place-items:center;width:30px;height:30px;border-radius:50%;background:var(--gold);color:#071126;font-weight:950;margin-bottom:12px}.price{font-size:34px;font-weight:950;color:#fff;margin:4px 0}.form{display:flex;gap:12px;flex-wrap:wrap;margin-top:16px}.form input{flex:1;min-width:220px;padding:14px 16px;border-radius:999px;border:1px solid var(--line);background:#081735;color:#fff;font-size:16px}.footer{margin:28px 0;color:var(--muted)}@media(max-width:900px){.grid,.grid.two,.grid.four,.steps{grid-template-columns:1fr}.hero{padding:28px}.nav{align-items:flex-start;flex-direction:column}}</style></head><body><div class="wrap"><nav class="nav"><a class="brand" href="/">QRV.NETWORK</a><div class="links">${nav.map(([path, label]) => `<a href="${path}">${label}</a>`).join('')}</div></nav>${body}<p class="footer">QRV.network is the public command hub. Operational services remain isolated on their service subdomains.</p></div></body></html>`;
 }
-async function registryReady() {
-  const response = await fetch(`${REGISTRY_BASE_URL}/ready`, { headers: { accept: 'application/json' } });
-  const registry = await response.json().catch(() => ({}));
-  return { ok: response.ok, registry };
+
+function sendPage(res, page) {
+  res.type('html').send(pageShell(page));
 }
 
-app.get('/ping', (_req, res) => res.status(200).json({ ok: true }));
-app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'issuer-qrv', version: VERSION, timestamp: now() }));
-app.get('/healthz', (_req, res) => res.json({ status: 'ok' }));
-app.get('/version', (_req, res) => res.json({ service: 'issuer-qrv', version: VERSION, appBaseUrl: APP_BASE_URL, registryBaseUrl: REGISTRY_BASE_URL, verifyBaseUrl: VERIFY_BASE_URL }));
-app.get(['/ready', '/readyz'], async (_req, res) => {
-  try {
-    const { ok, registry } = await registryReady();
-    res.status(ok ? 200 : 503).json({ ready: ok, registry, writeAuthConfigured: Boolean(ISSUER_API_KEY), service: 'issuer-qrv' });
-  } catch (error) {
-    res.status(503).json({ ready: false, error: error.message, writeAuthConfigured: Boolean(ISSUER_API_KEY), service: 'issuer-qrv' });
-  }
-});
+const services = [
+  { name: 'Verify Portal', host: 'verify.qrv.network', url: URLS.verify, role: 'Public verification trust surface', visibility: 'Public' },
+  { name: 'Issuer Portal', host: 'issuer.qrv.network', url: URLS.issuer, role: 'Issuer SaaS app for creating records', visibility: 'Issuer' },
+  { name: 'Registry Authority', host: 'registry.qrv.network', url: URLS.registry, role: 'Canonical record status and lifecycle authority', visibility: 'System' },
+  { name: 'API Gateway', host: 'api.qrv.network', url: URLS.api, role: 'JSON API gateway for issuance, lookup, and revocation', visibility: 'Developer' },
+  { name: 'Developer Docs', host: 'docs.qrv.network', url: URLS.docs, role: 'Standards, guides, payload examples, and API references', visibility: 'Public' },
+  { name: 'Developer Portal', host: 'developers.qrv.network', url: URLS.developers, role: 'SDKs, integration onboarding, and sandbox direction', visibility: 'Developer' },
+  { name: 'Status Center', host: 'status.qrv.network', url: URLS.status, role: 'Monitoring and incident communication', visibility: 'Public' },
+  { name: 'Store', host: 'store.qrv.network', url: URLS.store, role: 'WordPress/WooCommerce commerce and onboarding packages', visibility: 'Commercial' },
+  { name: 'Admin', host: 'admin.qrv.network', url: URLS.admin, role: 'Protected internal operations', visibility: 'Internal' }
+];
 
-app.get('/', (_req, res) => res.redirect('/dashboard'));
-app.get('/login', (_req, res) => {
-  res.type('html').send(layout(`<section class="hero"><div class="eyebrow">Secure issuer access</div><h1>Sign in to issue QR-V records.</h1><p>This production MVP expects authentication at the edge or Hostinger environment. Use this portal only for authorized issuers.</p><form method="get" action="/dashboard"><label>Issuer email</label><input name="email" type="email" placeholder="ops@example.com" required><label>Issuer access token</label><input name="token" type="password" placeholder="Configured outside this demo UI"><p><button type="submit">Continue to Dashboard</button></p></form></section>`, 'Issuer Login'));
-});
-app.get('/dashboard', async (_req, res) => {
-  let ready = false;
-  try { ready = (await registryReady()).ok; } catch { ready = false; }
-  const records = getRecords();
-  const scans = Array.from(scanCounts.values()).reduce((sum, count) => sum + Number(count || 0), 0);
-  res.type('html').send(layout(`${pageHeader('Issuer control plane', 'Create records, generate QRVIDs, revoke credentials, and track verification scans from one production portal.')}<section class="grid"><div class="card"><p class="eyebrow">Records</p><p class="stat">${records.length}</p><p>Issued in this portal runtime.</p></div><div class="card"><p class="eyebrow">Verification scans</p><p class="stat">${scans}</p><p>Tracked through issuer analytics endpoint.</p></div><div class="card"><p class="eyebrow">Registry readiness</p><p class="stat">${ready ? 'LIVE' : 'DOWN'}</p><p>${ready ? 'Registry can accept issuer writes.' : 'Registry readiness check is currently unavailable.'}</p></div></section><section class="card"><h2>Recent issuer activity</h2>${auditEvents.length ? `<ul>${auditEvents.slice(0, 8).map((event) => `<li><span class="mono">${escapeHtml(event.timestamp)}</span> ${escapeHtml(event.eventType)} ${escapeHtml(JSON.stringify(event.details))}</li>`).join('')}</ul>` : '<p>No audit events in this runtime yet.</p>'}</section>`, 'Issuer Dashboard'));
-});
-app.get('/records', (_req, res) => {
-  const records = getRecords();
-  res.type('html').send(layout(`${pageHeader('Issued records', 'Review QRVIDs created through the issuer portal and open their public verification pages.')}<section class="card"><h2>Records</h2>${records.length ? records.map(recordCard).join('') : '<p>No records have been issued in this runtime yet. Create the first one from /records/new.</p>'}</section>`, 'Issued Records'));
-});
-app.get(['/records/new', '/certificates', '/issue'], (_req, res) => {
-  res.type('html').send(layout(`<section class="hero"><div class="eyebrow">Create record</div><h1>Issue a registry-backed QRVID.</h1><form method="post" action="/issue"><label>Issuer</label><input name="issuer" value="${escapeHtml(DEFAULT_ISSUER_NAME)}" required><label>Recipient / Subject</label><input name="owner" placeholder="Jane Smith" required><label>Certificate or Record Title</label><input name="title" placeholder="Advanced Verification Certificate" required><label>Record Type</label><select name="type"><option value="certificate">Certificate</option><option value="membership-id">Membership ID</option><option value="product-authentication">Product Authentication</option><option value="document-verification">Document Verification</option><option value="asset-record">Asset Record</option></select><label>Expiration Date (optional)</label><input name="expiresAt" type="date"><label>Metadata</label><textarea name="metadata" rows="4" placeholder="Course, credential, SKU, document reference, or notes"></textarea><p><button type="submit">Create Verifiable Record</button></p></form></section>`, 'Create QR-V Record'));
-app.get('/ping', (_req, res) => res.status(200).type('text/plain').send('pong'));
-app.get('/health', (_req, res) => res.status(200).json({ status: 'ok', service: 'qrv-marketing-site', version: VERSION, timestamp: now() }));
-app.get('/healthz', (_req, res) => res.status(200).json({ status: 'ok' }));
-app.get('/ready', (_req, res) => res.status(200).json({ ready: true, service: 'qrv-marketing-site', version: VERSION, urls: URLS }));
-app.get('/readyz', (_req, res) => res.status(200).json({ ready: true }));
-app.get('/version', (_req, res) => res.status(200).json({ service: 'qrv-marketing-site', version: VERSION, node: process.version, urls: URLS }));
+const pricingPlans = [
+  { name: 'Starter Issuer', price: '$199/month', body: 'First production issuer plan for small certificate programs and low-volume launch programs.' },
+  { name: 'Growth Issuer', price: '$499/month', body: 'For growing issuers with repeat issuance workflows and higher monthly verification volume.' },
+  { name: 'Professional Issuer', price: '$1,500/month', body: 'For mature certificate operations that need support, reporting, and lifecycle controls.' },
+  { name: 'Enterprise / Network Issuer', price: '$5,000+/month', body: 'For institutions, multi-issuer networks, SLAs, custom integrations, and governance support.' }
+];
 
-app.get('/issue', (_req, res) => {
-  sendPage(res, standardPage({ path: '/issue', title: 'Issue QR-V Certificate', eyebrow: 'Issuer utility', heading: 'Create a QR-V certificate record.', lead: 'This compatibility route preserves the issuer MVP form while the root site becomes the public qrv.network marketing site.', cards: [], extra: `<section class="section"><form method="post" action="/issue"><label>Issuer</label><input name="issuer" value="${escapeHtml(DEFAULT_ISSUER_NAME)}" required><label>Recipient / Subject</label><input name="owner" placeholder="Jane Smith" required><label>Certificate Title</label><input name="title" placeholder="Advanced Verification Certificate" required><label>Record Type</label><input name="type" value="certificate" required><label>Metadata</label><textarea name="metadata" rows="4" placeholder="Course, credential, program, or notes"></textarea><p><button type="submit">Create Verifiable Record</button></p></form></section>` }));
+function networkDirectorySection() {
+  return `<section class="section"><p class="eyebrow">Network Directory</p><h2>One brand hub, separate operational services.</h2><p class="lead">QRV.network consolidates navigation, commercial messaging, docs, demos, and service discovery while preserving dedicated production endpoints for trust, issuance, registry, API, docs, monitoring, commerce, and operations.</p><div class="grid">${services.map((service) => `<article class="card"><span class="pill ${service.visibility === 'Internal' ? 'private' : 'live'}">${escapeHtml(service.visibility)}</span><h3>${escapeHtml(service.name)}</h3><p>${escapeHtml(service.role)}</p><p class="mono">${escapeHtml(service.host)}</p><a class="btn alt" href="${escapeHtml(service.url)}">Open service</a></article>`).join('')}</div></section>`;
+}
+
+function activationSection() {
+  const steps = ['Create Certificate', 'Save Through API', 'Store In Registry', 'Verify Publicly', 'Return VERIFIED'];
+  return `<section class="section"><p class="eyebrow">First Live Activation</p><h2>The certificate lifecycle QRV.network is organizing around.</h2><div class="steps">${steps.map((step) => `<div class="step"><h3>${escapeHtml(step)}</h3><p>${step === 'Return VERIFIED' ? 'The relying-party result resolves from live registry status.' : 'Part of the issuer → API → registry → verify production path.'}</p></div>`).join('')}</div><div><a class="btn" href="${escapeHtml(URLS.issuer)}/records/new">Issue Certificate</a><a class="btn blue" href="${escapeHtml(verifyUrl(DEMO_QRVID))}">Verify Demo Record</a><a class="btn alt" href="${escapeHtml(URLS.docs)}">View API Docs</a><a class="btn alt" href="/pricing">View Plans</a></div></section>`;
+}
+
+function demoSection() {
+  return `<section class="section"><p class="eyebrow">Live Demo</p><h2>Try a verified QR-V record.</h2><p class="lead">Use the demo identifier below to validate that the public verification trust surface resolves records from the QR-V network.</p><div class="card"><h3 class="mono">${DEMO_QRVID}</h3><p><a class="btn" href="${escapeHtml(verifyUrl(DEMO_QRVID))}">Open ${escapeHtml(DEMO_QRVID)}</a><a class="btn alt" href="/verify?qrvid=${encodeURIComponent(DEMO_QRVID)}">Test root redirect</a></p></div></section>`;
+}
+
+function pricingSection() {
+  return `<section class="section"><p class="eyebrow">Pricing / Commercial Entry</p><h2>Issuer Portal pricing routes checkout to the store.</h2><div class="grid four">${pricingPlans.map((plan) => `<article class="card"><h3>${escapeHtml(plan.name)}</h3><p class="price">${escapeHtml(plan.price)}</p><p>${escapeHtml(plan.body)}</p><a class="btn" href="${escapeHtml(URLS.store)}">Start checkout</a></article>`).join('')}</div></section>`;
+}
+
+function publicHero() {
+  return `<section class="hero"><p class="eyebrow">QR-V Network Command Hub</p><h1>Verification infrastructure, consolidated at QRV.network.</h1><p class="lead">Use the root domain for discovery, demos, pricing, developer navigation, status links, and commercial entry. Keep the production trust surfaces on their dedicated subdomains.</p><form class="form" method="post" action="/verify"><input name="qrvid" placeholder="Enter QRVID, e.g. ${DEMO_QRVID}" aria-label="QRVID"><button type="submit">Verify QRVID</button></form><p><a class="btn" href="${escapeHtml(URLS.issuer)}">Issue Certificate</a><a class="btn blue" href="${escapeHtml(verifyUrl(DEMO_QRVID))}">Verify Demo Record</a><a class="btn alt" href="${escapeHtml(URLS.docs)}">View API Docs</a><a class="btn alt" href="/pricing">View Plans</a></p></section>`;
+}
+
+function rootPage() {
+  return {
+    title: 'QRV.network | QR-V Network Command Hub',
+    description: 'QRV.network consolidates QR-V service discovery, demos, docs, pricing, and status while operational services remain on subdomains.',
+    body: `${publicHero()}${networkDirectorySection()}${activationSection()}${demoSection()}${pricingSection()}`
+  };
+}
+
+function routePage({ title, eyebrow, heading, lead, primaryLabel, primaryUrl, secondaryLabel, secondaryUrl, extra = '' }) {
+  return {
+    title: `${title} | QRV.network`,
+    description: lead,
+    body: `<section class="hero"><p class="eyebrow">${escapeHtml(eyebrow)}</p><h1>${escapeHtml(heading)}</h1><p class="lead">${escapeHtml(lead)}</p><p><a class="btn" href="${escapeHtml(primaryUrl)}">${escapeHtml(primaryLabel)}</a>${secondaryLabel ? `<a class="btn alt" href="${escapeHtml(secondaryUrl)}">${escapeHtml(secondaryLabel)}</a>` : ''}</p></section>${extra}`
+  };
+}
+
+app.get('/ping', (_req, res) => res.type('text').send('pong'));
+app.get(['/health', '/healthz'], (_req, res) => res.json({ ok: true, service: 'qrv-marketing-site', role: 'root-command-hub', version: VERSION, timestamp: now() }));
+app.get(['/ready', '/readyz'], (_req, res) => res.json({ ok: true, service: 'qrv-marketing-site', dependenciesRequiredForRender: false, timestamp: now() }));
+app.get('/version', (_req, res) => res.json({ service: 'qrv-marketing-site', version: VERSION, node: process.version }));
+
+app.get('/', (_req, res) => sendPage(res, rootPage()));
+app.get('/network', (_req, res) => sendPage(res, routePage({ title: 'Network Directory', eyebrow: 'Network Directory', heading: 'Every QR-V service, role, and endpoint.', lead: 'QRV.network shows the full service family without collapsing operational trust boundaries.', primaryLabel: 'Verify Demo Record', primaryUrl: verifyUrl(DEMO_QRVID), secondaryLabel: 'Open Status Center', secondaryUrl: URLS.status, extra: networkDirectorySection() })));
+app.get('/verify', (req, res) => {
+  const qrvid = cleanQrvid(req.query?.qrvid);
+  if (qrvid) return res.redirect(302, verifyUrl(qrvid));
+  return sendPage(res, routePage({ title: 'Verify', eyebrow: 'Verify', heading: 'Verify QR-V records on the public trust surface.', lead: 'Root-domain verification entry routes QRVID lookups to verify.qrv.network, the dedicated public verification service.', primaryLabel: 'Verify Demo Record', primaryUrl: verifyUrl(DEMO_QRVID), secondaryLabel: 'Open Verify Portal', secondaryUrl: URLS.verify, extra: demoSection() }));
 });
-app.post('/issue', async (req, res) => {
-  try {
-    const { issuer, owner, title, type, metadata, expiresAt } = req.body;
-    const result = await createRegistryRecord({ type: type || 'certificate', issuer, owner, title, expiresAt: expiresAt || null, payload: { metadata, source: 'issuer-qrv', issuedAt: now() } });
-    addAudit('record.created', { qrvid: result.qrvid, type: result.recordType || result.type });
-    res.type('html').send(layout(`<section class="card success"><h1>Record Issued</h1><p>Certificate record created successfully.</p><div class="grid two"><div><p><strong>QRVID</strong></p><p class="mono">${escapeHtml(result.qrvid)}</p><p><strong>Verification URL</strong></p><p class="mono">${escapeHtml(result.verifyUrl)}</p><p><strong>Hash</strong></p><p class="mono">${escapeHtml(result.hash || 'Registry hash pending')}</p><p><a class="btn" href="${escapeHtml(result.verifyUrl)}">Open Verification Page</a> <a class="btn alt" href="/records/new">Issue Another</a></p></div><div><img class="qr" alt="QR code for ${escapeHtml(result.qrvid)}" src="${escapeHtml(result.qrCodeUrl)}"></div></div></section>`,'Record Issued'));
-  } catch (error) {
-    res.status(502).type('html').send(layout(`<section class="card error"><h1>Issue Failed</h1><p>${escapeHtml(error.message)}</p><p><a class="btn" href="/records/new">Try Again</a></p></section>`,'Issue Failed'));
-    const { issuer, owner, title, type, metadata } = req.body;
-    const result = await createRegistryRecord({ type: type || 'certificate', issuer, owner, payload: { title, metadata, source: 'qrv-network-root', issuedAt: now() } });
-    const verifyUrl = result.verifyUrl || `${URLS.verify}/${encodeURIComponent(result.qrvid)}`;
-    sendPage(res, { path: '/issue', title: 'Record Issued | QR-V Network', description: 'Record issued.', body: `<section class="route-title"><p class="eyebrow">Issued</p><h1>Record issued.</h1><p class="lead">Certificate record created successfully.</p></section><section class="section"><p><strong>QRVID</strong></p><p class="mono">${escapeHtml(result.qrvid)}</p><p><strong>Hash</strong></p><p class="mono">${escapeHtml(result.hash)}</p><a class="btn" href="${escapeHtml(verifyUrl)}">Open verification page</a> <a class="btn alt" href="/issue">Issue another</a></section>` });
-  } catch (error) {
-    res.status(500);
-    sendPage(res, { path: '/issue', title: 'Issue Failed | QR-V Network', description: 'Issue failed.', body: `<section class="route-title"><p class="eyebrow">Error</p><h1>Issue failed.</h1><p class="lead">${escapeHtml(error.message)}</p><a class="btn" href="/issue">Try again</a></section>` });
-  }
-});
-app.get('/revoke', (_req, res) => {
-  const qrvid = _req.query.qrvid || '';
-  res.type('html').send(layout(`<section class="hero"><div class="eyebrow">Revoke record</div><h1>Revoke a QRVID.</h1><p>Revocation updates the registry and forces the public verifier to return REVOKED.</p><form method="post" action="/revoke"><label>QRVID</label><input name="qrvid" value="${escapeHtml(qrvid)}" placeholder="QRV-PROD-CERT-000002" required><label>Revocation reason</label><textarea name="reason" rows="3" placeholder="Credential withdrawn, issued in error, account closed..." required></textarea><p><button type="submit">Revoke Record</button></p></form></section>`, 'Revoke QRVID'));
-});
-app.post('/revoke', async (req, res) => {
-  try {
-    const result = await revokeRegistryRecord(req.body.qrvid, req.body.reason);
-    res.type('html').send(layout(`<section class="card success"><h1>Record Revoked</h1><p>The registry accepted the revocation.</p>${recordCard(result)}<p><a class="btn" href="/records">Back to Records</a></p></section>`, 'Record Revoked'));
-  } catch (error) {
-    res.status(502).type('html').send(layout(`<section class="card error"><h1>Revoke Failed</h1><p>${escapeHtml(error.message)}</p><p><a class="btn" href="/revoke">Try Again</a></p></section>`, 'Revoke Failed'));
-  }
-});
-app.get('/api-keys', (_req, res) => {
-  res.type('html').send(layout(`${pageHeader('API keys', 'Use issuer API keys to automate record creation and revocation from your own systems.')}<section class="card"><h2>Configured key status</h2><p class="mono">ISSUER_API_KEY / REGISTRY_API_KEY configured: ${ISSUER_API_KEY ? 'YES' : 'NO'}</p><p>For production, create issuer-scoped keys in the registry authority, store them in Hostinger environment variables, and rotate immediately if a key appears in screenshots or support tickets.</p><h3>Automation endpoints</h3><ul><li><span class="mono">POST /api/issue</span> creates a record.</li><li><span class="mono">POST /api/revoke/:qrvid</span> revokes a record.</li><li><span class="mono">POST /api/analytics/scan</span> records a verification scan.</li></ul></section>`, 'Issuer API Keys'));
-});
-app.get('/settings', (_req, res) => {
-  res.type('html').send(layout(`${pageHeader('Issuer settings', 'Confirm production URLs and runtime configuration before issuing customer records.')}<section class="card"><h2>Environment</h2><p class="mono">APP_BASE_URL=${escapeHtml(APP_BASE_URL)}</p><p class="mono">VERIFY_BASE_URL=${escapeHtml(VERIFY_BASE_URL)}</p><p class="mono">REGISTRY_BASE_URL=${escapeHtml(REGISTRY_BASE_URL)}</p><p class="mono">APP_VERSION=${escapeHtml(VERSION)}</p><p class="mono">RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS}</p><p class="mono">RATE_LIMIT_MAX=${RATE_LIMIT_MAX}</p></section>`, 'Issuer Settings'));
-});
-app.get('/billing', (_req, res) => {
-  res.type('html').send(layout(`${pageHeader('Billing', 'Monetize QR-V issuance with paid issuer plans tied to record volume and scan analytics.')}<section class="grid"><div class="card"><h2>Starter</h2><p class="stat">$99</p><p>For pilots and first certificate programs.</p></div><div class="card"><h2>Growth</h2><p class="stat">$299</p><p>For production issuers with larger monthly volume.</p></div><div class="card"><h2>Enterprise</h2><p class="stat">Custom</p><p>Dedicated support, SLAs, and custom integrations.</p></div></section><section class="card"><h2>Stripe readiness</h2><p class="mono">STRIPE_SECRET_KEY configured: ${process.env.STRIPE_SECRET_KEY ? 'YES' : 'NO'}</p><p class="mono">STRIPE_PRICE_STARTER configured: ${process.env.STRIPE_PRICE_STARTER ? 'YES' : 'NO'}</p><p class="mono">STRIPE_PRICE_GROWTH configured: ${process.env.STRIPE_PRICE_GROWTH ? 'YES' : 'NO'}</p></section>`, 'Issuer Billing'));
-});
+app.get('/issuer', (_req, res) => sendPage(res, routePage({ title: 'Issuer Portal', eyebrow: 'Issuer', heading: 'Create certificates through the issuer SaaS app.', lead: 'Issuer workflows remain on issuer.qrv.network while QRV.network explains plans, activation, and routing.', primaryLabel: 'Issue Certificate', primaryUrl: `${URLS.issuer}/records/new`, secondaryLabel: 'View Plans', secondaryUrl: '/pricing', extra: activationSection() })));
+app.get('/docs', (_req, res) => sendPage(res, routePage({ title: 'Docs', eyebrow: 'Documentation', heading: 'Read standards, issuer guides, and API references.', lead: 'Documentation is served from docs.qrv.network with root-domain navigation for discovery.', primaryLabel: 'View API Docs', primaryUrl: URLS.docs, secondaryLabel: 'Developer Portal', secondaryUrl: URLS.developers })));
+app.get('/developers', (_req, res) => sendPage(res, routePage({ title: 'Developers', eyebrow: 'Developers', heading: 'Integrate QR-V issuance, lookup, and revocation.', lead: 'The developer portal, SDKs, and integration onboarding remain separated at developers.qrv.network.', primaryLabel: 'Open Developer Portal', primaryUrl: URLS.developers, secondaryLabel: 'View API Gateway', secondaryUrl: URLS.api })));
+app.get('/pricing', (_req, res) => sendPage(res, routePage({ title: 'Pricing', eyebrow: 'Pricing', heading: 'Choose an issuer plan and check out through the store.', lead: 'QRV.network presents the commercial gateway; store.qrv.network owns WooCommerce checkout and onboarding purchases.', primaryLabel: 'Start Checkout', primaryUrl: URLS.store, secondaryLabel: 'Issue Certificate', secondaryUrl: `${URLS.issuer}/records/new`, extra: pricingSection() })));
+app.get('/status', (_req, res) => sendPage(res, routePage({ title: 'Status', eyebrow: 'Status', heading: 'Monitor the QR-V service family.', lead: 'Status monitoring remains on status.qrv.network while QRV.network links the health surface from the hub.', primaryLabel: 'Open Status Center', primaryUrl: URLS.status, secondaryLabel: 'View Network Directory', secondaryUrl: '/network', extra: networkDirectorySection() })));
+app.get('/store', (_req, res) => sendPage(res, routePage({ title: 'Store', eyebrow: 'Store', heading: 'Purchase issuer plans and onboarding packages.', lead: 'The commerce surface remains on store.qrv.network so WordPress/WooCommerce can operate separately from trust services.', primaryLabel: 'Open Store', primaryUrl: URLS.store, secondaryLabel: 'View Plans', secondaryUrl: '/pricing', extra: pricingSection() })));
+
+
+app.get('/protocol', (_req, res) => sendPage(res, routePage({ title: 'Protocol', eyebrow: 'Protocol', heading: 'QR-V connects QRVIDs to live registry-backed status.', lead: 'The protocol pattern separates issuer claims, registry lifecycle state, public verification, and relying-party review.', primaryLabel: 'View API Docs', primaryUrl: URLS.docs, secondaryLabel: 'View Network Directory', secondaryUrl: '/network', extra: activationSection() })));
+app.get('/how-it-works', (_req, res) => sendPage(res, routePage({ title: 'How It Works', eyebrow: 'How It Works', heading: 'Issuer → API → Registry → Verify → VERIFIED.', lead: 'The command hub explains the first live certificate lifecycle and sends each operational step to the correct service subdomain.', primaryLabel: 'Issue Certificate', primaryUrl: `${URLS.issuer}/records/new`, secondaryLabel: 'Verify Demo Record', secondaryUrl: verifyUrl(DEMO_QRVID), extra: activationSection() })));
+app.get('/registry', (_req, res) => sendPage(res, routePage({ title: 'Registry', eyebrow: 'Registry Authority', heading: 'Canonical lifecycle state stays on registry.qrv.network.', lead: 'QRV.network presents registry context while the registry authority remains isolated as its own operational service.', primaryLabel: 'Open Registry Authority', primaryUrl: URLS.registry, secondaryLabel: 'View API Gateway', secondaryUrl: URLS.api })));
+app.get(['/use-cases', '/use-cases/certificates', '/use-cases/membership-id', '/use-cases/product-authentication', '/use-cases/document-verification', '/use-cases/asset-records'], (req, res) => sendPage(res, routePage({ title: 'Use Cases', eyebrow: 'Use Cases', heading: 'QR-V supports verifiable certificates, IDs, products, documents, and assets.', lead: `This use-case page (${req.path}) routes prospects toward the issuer portal, docs, demo verifier, and pricing gateway.`, primaryLabel: 'Issue Certificate', primaryUrl: `${URLS.issuer}/records/new`, secondaryLabel: 'View Plans', secondaryUrl: '/pricing', extra: demoSection() })));
+app.get('/book-demo', (_req, res) => sendPage(res, routePage({ title: 'Book Demo', eyebrow: 'Demo', heading: 'See the QR-V certificate lifecycle end to end.', lead: 'Start with the live demo record, then choose an issuer plan or open the issuer portal for production activation.', primaryLabel: 'Verify Demo Record', primaryUrl: verifyUrl(DEMO_QRVID), secondaryLabel: 'View Plans', secondaryUrl: '/pricing', extra: activationSection() })));
+app.get('/about', (_req, res) => sendPage(res, routePage({ title: 'About', eyebrow: 'About', heading: 'QR-V is verification infrastructure for real-world records.', lead: 'QRV.network is the public hub for explaining the service family and routing users to separated operational domains.', primaryLabel: 'View Network Directory', primaryUrl: '/network', secondaryLabel: 'Open Status Center', secondaryUrl: URLS.status })));
+app.get('/security', (_req, res) => sendPage(res, routePage({ title: 'Security', eyebrow: 'Security', heading: 'Trust boundaries stay separated by service role.', lead: 'Verification, issuance, registry authority, APIs, docs, status, commerce, and administration remain on scoped subdomains.', primaryLabel: 'View Network Directory', primaryUrl: '/network', secondaryLabel: 'Open Status Center', secondaryUrl: URLS.status })));
+app.get(['/legal', '/privacy', '/terms'], (req, res) => sendPage(res, routePage({ title: 'Legal', eyebrow: 'Legal', heading: 'QR-V provides infrastructure; issuers remain responsible for claims.', lead: `This public policy route (${req.path}) summarizes the root trust disclaimer and routes operational use to the relevant service.`, primaryLabel: 'Return Home', primaryUrl: '/', secondaryLabel: 'View Network Directory', secondaryUrl: '/network' })));
 
 app.post('/verify', (req, res) => {
   const qrvid = cleanQrvid(req.body?.qrvid);
-  if (!qrvid) return res.redirect(303, '/');
-  return res.redirect(303, `${URLS.verify}/${encodeURIComponent(qrvid)}`);
+  if (!qrvid) return res.redirect(303, '/verify');
+  return res.redirect(303, verifyUrl(qrvid));
 });
 
-app.get('/verify', (req, res) => {
-  const qrvid = cleanQrvid(req.query?.qrvid);
-  if (!qrvid) return res.redirect(302, URLS.verify);
-  return res.redirect(302, `${URLS.verify}/${encodeURIComponent(qrvid)}`);
+app.get(['/dashboard', '/records', '/records/new', '/certificates', '/issue', '/revoke', '/api-keys', '/settings', '/billing'], (req, res) => {
+  res.redirect(302, `${URLS.issuer}${req.path}`);
 });
 
 app.post('/api/issue', async (req, res) => {
@@ -386,6 +287,7 @@ app.post('/api/issue', async (req, res) => {
     res.status(502).json({ ok: false, status: 'UNAVAILABLE', error: error.message });
   }
 });
+
 app.get('/api/records', (_req, res) => res.json({ ok: true, records: getRecords() }));
 app.get('/api/records/:qrvid', async (req, res) => {
   try {
@@ -404,7 +306,7 @@ app.post('/api/revoke/:qrvid', async (req, res) => {
   }
 });
 app.post('/api/analytics/scan', (req, res) => {
-  const qrvid = String(req.body?.qrvid || '').trim();
+  const qrvid = cleanQrvid(req.body?.qrvid);
   if (!qrvid) return res.status(400).json({ ok: false, status: 'INVALID_FORMAT', error: 'qrvid is required' });
   const scans = Number(scanCounts.get(qrvid) || 0) + 1;
   scanCounts.set(qrvid, scans);
@@ -413,14 +315,9 @@ app.post('/api/analytics/scan', (req, res) => {
   res.json({ ok: true, qrvid, scans, timestamp: now() });
 });
 
-app.use((req, res) => res.status(404).type('html').send(layout(`<section class="card error"><h1>Not Found</h1><p>The requested issuer route does not exist.</p><p class="mono">${escapeHtml(req.path)}</p></section>`, 'Not Found')));
-for (const [path, factory] of pages.entries()) {
-  app.get(path, (_req, res) => sendPage(res, factory()));
-}
-
 app.use((req, res) => {
   res.status(404);
-  sendPage(res, { path: req.path, title: 'Not Found | QR-V Network', description: 'QR-V route not found.', body: `<section class="route-title"><p class="eyebrow">404</p><h1>Route not found.</h1><p class="lead">The requested QR-V Network page does not exist.</p><p class="mono">${escapeHtml(req.path)}</p><div class="actions"><a class="btn" href="/">Return home</a><a class="btn alt" href="/use-cases">View use cases</a></div></section>` });
+  sendPage(res, routePage({ title: 'Not Found', eyebrow: '404', heading: 'Route not found.', lead: `The requested QR-V Network page does not exist: ${req.path}`, primaryLabel: 'Return home', primaryUrl: '/', secondaryLabel: 'View Network Directory', secondaryUrl: '/network' }));
 });
 
 app.use((err, _req, res, _next) => {


### PR DESCRIPTION
### Motivation
- Provide a single public command hub at `qrv.network` that consolidates discovery, demos, pricing, and routing while preserving operational services on their own subdomains. 
- Surface a clear first-live activation flow (issuer → API → registry → verify → VERIFIED) and make it easy for visitors to find the Verify, Issuer, Registry, API, Docs, Developers, Status, Store, and Admin endpoints from the root domain.

### Description
- Rebuilt `server.js` into a dedicated QRV.network Express command-hub that serves `/`, `/verify`, `/issuer`, `/docs`, `/developers`, `/pricing`, `/status`, `/store`, and `/network` plus legacy marketing paths, and keeps redirects/hand-offs to service subdomains (e.g. `verify.qrv.network`, `issuer.qrv.network`).
- Added Network Directory, First Live Activation steps, Live Demo block using `QRV-DEMO-001`, and a Pricing/Store gateway that routes checkout to `store.qrv.network`; introduced `DEMO_QRVID` and updated pricing plan text.
- Implemented registry compatibility helpers and API compatibility handlers: `requestJson`, `normalizeRegistryRecord`, `createRegistryRecord`, `fetchRegistryRecord`, and `revokeRegistryRecord`, and kept issuer compatibility endpoints under `/api/*` and redirects for issuer UI paths to `issuer.qrv.network`.
- Cleaned and expanded `.env.example` (added `QRV_ADMIN_URL`, `QRV_STORE_URL`, `QRV_SECURITY_URL`, updated CORS list, pricing placeholders, etc.) and updated `README.md` with the root-domain model, demo QRVID, pricing, and `verify.qrv.network` 503 triage steps.

### Testing
- Ran static syntax/type checks: `npm run check` — passed.
- Built noop Hostinger-compatible build: `npm run build` — passed.
- Started local server and exercised routes: `PORT=3010 npm start` then validated `/healthz`, `/network` (network directory content), `/pricing` (prices present), `/protocol` (compatibility copy) and `GET /verify?qrvid=QRV-DEMO-001` returned an HTTP `302` redirect to `https://verify.qrv.network/QRV-DEMO-001` — all successful locally.
- Ran `npm run smoke:domains` (external smoke checks) — failed because external QRV subdomains were unreachable from this environment.
- Performed remote check `curl -I --max-time 10 https://verify.qrv.network/healthz` — observed Hostinger `503 Service Unavailable`, recorded in the README triage steps as the deployment fix that must be addressed.
- Attempted an automated screenshot with Playwright; browser dependencies were installed and a screenshot artifact was produced locally, but browser download/install steps required host deps and the screenshot artifact was not committed to the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259b4d3e7c832d86a3a612f63ef22d)