### PR TITLE
Add live domain deployment map and audit script

### DIFF
--- a/docs/live-domain-map.md
+++ b/docs/live-domain-map.md
@@ -1,0 +1,74 @@
+# QRV live domain deployment map
+
+This document is the deployment contract for the live QRV production hostnames. It records the required repository/service owner, framework, runtime entry file, environment variables, and smoke-test URLs for each live domain.
+
+## Required live mapping
+
+| Live domain | Required repo / service | Framework / runtime | Runtime entry file | Required environment variables | Test URLs |
+| --- | --- | --- | --- | --- | --- |
+| `qrv.network` | `qrv-node` | Node.js / Express command hub | `server.js` | `NODE_ENV`, `APP_ENV`, `PORT`, `APP_VERSION`, `APP_BASE_URL`, `QRV_PUBLIC_SITE_URL`, `QRV_VERIFY_URL`, `QRV_ISSUER_URL`, `QRV_REGISTRY_URL`, `QRV_API_URL`, `QRV_STORE_URL`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX` | `https://qrv.network`, `https://qrv.network/status` |
+| `api.qrv.network` | `qrv-api` | Node.js JSON API service | `server.js` | `NODE_ENV`, `APP_ENV`, `PORT`, `APP_VERSION`, `DATABASE_URL`, `REGISTRY_BASE_URL`, `VERIFY_BASE_URL`, `CORS_ALLOWED_ORIGINS`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX` | `https://api.qrv.network/healthz` |
+| `registry.qrv.network` | `qrv-registry` | Node.js registry/status service | `server.js` | `NODE_ENV`, `APP_ENV`, `PORT`, `APP_VERSION`, `DATABASE_URL`, `REGISTRY_API_KEY`, `SIGNING_SECRET`, `CORS_ALLOWED_ORIGINS`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX` | `https://registry.qrv.network` |
+| `issuer.qrv.network` | `issuer-qrv` | Next.js App Router issuer application | `app/page.tsx`, `middleware.ts` | `NODE_ENV`, `APP_ENV`, `PORT`, `APP_VERSION`, `APP_BASE_URL`, `NEXT_PUBLIC_APP_ROLE=issuer`, `NEXT_PUBLIC_QRV_API_BASE_URL`, `NEXT_PUBLIC_QRV_VERIFY_BASE_URL`, `NEXT_PUBLIC_QRV_REGISTRY_BASE_URL`, `ISSUER_API_KEY`, `DATABASE_URL`, `JWT_SECRET`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_SUCCESS_URL`, `STRIPE_CANCEL_URL` | `https://issuer.qrv.network/login`, `https://issuer.qrv.network/healthz` |
+| `verify.qrv.network` | Public verification runtime | Next.js App Router public verification application | `app/page.tsx`, `app/[qrvid]/page.tsx`, `middleware.ts` | `NODE_ENV`, `APP_ENV`, `PORT`, `APP_VERSION`, `NEXT_PUBLIC_APP_ROLE=verify`, `NEXT_PUBLIC_QRV_API_BASE_URL`, `NEXT_PUBLIC_QRV_VERIFY_BASE_URL`, `NEXT_PUBLIC_QRV_REGISTRY_BASE_URL` | `https://verify.qrv.network`, `https://verify.qrv.network/QRV-DEMO-001` |
+| `store.qrv.network` | WordPress / WooCommerce production install | WordPress / PHP | `index.php`, `wp-config.php`, active theme/plugin entry files | `WORDPRESS_DB_HOST`, `WORDPRESS_DB_NAME`, `WORDPRESS_DB_USER`, `WORDPRESS_DB_PASSWORD`, `WP_HOME=https://store.qrv.network`, `WP_SITEURL=https://store.qrv.network`, payment-provider secrets configured in WordPress/WooCommerce admin | `https://store.qrv.network` |
+
+## Domain-specific notes
+
+### `qrv.network` → `qrv-node`
+
+- Purpose: public command hub and navigation surface for the QRV network.
+- The root URL must return HTML for the hub page.
+- `/status` must return the hub status page with links to the live service domains.
+- It must not replace or proxy the issuer, verify, API, registry, or store runtimes.
+
+### `api.qrv.network` → `qrv-api`
+
+- Purpose: JSON API gateway for health, issuance, lookup, and revocation flows.
+- `/healthz` must return JSON and be safe for uptime monitors.
+- API responses must not render issuer or verification HTML.
+
+### `registry.qrv.network` → `qrv-registry`
+
+- Purpose: canonical registry/status authority for QRVID lifecycle state.
+- The root URL should return a registry/status response that identifies the registry service or its health/status.
+- Registry writes must require service credentials; public smoke tests should stay read-only.
+
+### `issuer.qrv.network` → `issuer-qrv`
+
+- Purpose: issuer-facing SaaS application for login, dashboard, credential issuance, revocation, billing, and API keys.
+- `/login` must return issuer login HTML.
+- Issuer-only pages must remain on `issuer.qrv.network`; public verification results must remain on `verify.qrv.network`.
+
+### `verify.qrv.network` → public verification runtime
+
+- Purpose: public, relying-party verification surface.
+- `/QRV-DEMO-001` must return a styled verification result page for the demo QRVID.
+- Verification pages must call the public API base from `NEXT_PUBLIC_QRV_API_BASE_URL` and display public status only.
+
+### `store.qrv.network` → WordPress
+
+- Purpose: WordPress/WooCommerce commerce, checkout, and onboarding package surface.
+- The store is intentionally outside the Node.js service family.
+- Node applications should link to the store for purchase/checkout flows instead of rendering checkout locally.
+
+## Automated audit
+
+Run the live-domain audit from this repository:
+
+```bash
+npm run audit:live
+```
+
+The audit checks the required production URLs and prints `PASS` or `FAIL` for each domain check. A non-zero exit code means one or more required live mappings failed the audit.
+
+The audit URL defaults can be overridden with these environment variables when testing staging cutovers or alternate DNS targets:
+
+- `QRV_AUDIT_ROOT_URL`
+- `QRV_AUDIT_ROOT_STATUS_URL`
+- `QRV_AUDIT_API_HEALTHZ_URL`
+- `QRV_AUDIT_REGISTRY_URL`
+- `QRV_AUDIT_ISSUER_LOGIN_URL`
+- `QRV_AUDIT_VERIFY_DEMO_URL`
+- `QRV_AUDIT_TIMEOUT_MS`
+- `QRV_AUDIT_USER_AGENT`

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "NODE_ENV=development node server.js",
     "acceptance:live": "node scripts/acceptance-live.mjs",
     "smoke:domains": "node scripts/smoke-domain-content-type.mjs",
-    "smoke:production": "node scripts/smoke-production.mjs"
+    "smoke:production": "node scripts/smoke-production.mjs",
+    "audit:live": "node scripts/audit-live-domains.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/scripts/audit-live-domains.mjs
+++ b/scripts/audit-live-domains.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+const DEFAULT_TIMEOUT_MS = Number(process.env.QRV_AUDIT_TIMEOUT_MS || 15_000);
+const USER_AGENT = process.env.QRV_AUDIT_USER_AGENT || 'QRV-Live-Domain-Audit/1.0';
+
+const checks = [
+  {
+    domain: 'qrv.network',
+    role: 'Hub HTML',
+    url: process.env.QRV_AUDIT_ROOT_URL || 'https://qrv.network',
+    expected: 'hub HTML',
+    validate: validateHubHtml,
+  },
+  {
+    domain: 'qrv.network',
+    role: 'Hub status',
+    url: process.env.QRV_AUDIT_ROOT_STATUS_URL || 'https://qrv.network/status',
+    expected: 'hub status page',
+    validate: validateHubStatus,
+  },
+  {
+    domain: 'api.qrv.network',
+    role: 'API health',
+    url: process.env.QRV_AUDIT_API_HEALTHZ_URL || 'https://api.qrv.network/healthz',
+    expected: 'API health JSON',
+    validate: validateApiHealthJson,
+  },
+  {
+    domain: 'registry.qrv.network',
+    role: 'Registry status',
+    url: process.env.QRV_AUDIT_REGISTRY_URL || 'https://registry.qrv.network',
+    expected: 'registry/status response',
+    validate: validateRegistryStatus,
+  },
+  {
+    domain: 'issuer.qrv.network',
+    role: 'Issuer login',
+    url: process.env.QRV_AUDIT_ISSUER_LOGIN_URL || 'https://issuer.qrv.network/login',
+    expected: 'issuer login HTML',
+    validate: validateIssuerLogin,
+  },
+  {
+    domain: 'verify.qrv.network',
+    role: 'Styled verification result',
+    url: process.env.QRV_AUDIT_VERIFY_DEMO_URL || 'https://verify.qrv.network/QRV-DEMO-001',
+    expected: 'styled verification result HTML',
+    validate: validateStyledVerificationResult,
+  },
+];
+
+function normalize(value) {
+  return String(value || '').toLowerCase();
+}
+
+function hasHtmlContentType(contentType) {
+  return normalize(contentType).includes('text/html');
+}
+
+function hasJsonContentType(contentType) {
+  return normalize(contentType).includes('application/json') || normalize(contentType).includes('+json');
+}
+
+function requireStatus(response, allowedStatuses = [200]) {
+  if (!allowedStatuses.includes(response.status)) {
+    return `expected HTTP ${allowedStatuses.join(' or ')}, got ${response.status}`;
+  }
+
+  return null;
+}
+
+function requireAnyBodyMatch(body, patterns, label) {
+  if (patterns.some((pattern) => pattern.test(body))) {
+    return null;
+  }
+
+  return `expected body to include ${label}`;
+}
+
+function formatError(error) {
+  if (!(error instanceof Error)) return String(error);
+
+  const cause = error.cause;
+  if (cause instanceof Error) {
+    const code = typeof cause.code === 'string' ? cause.code : '';
+    const message = cause.message || code;
+    const suffix = [code, message].filter(Boolean).join(' ');
+    return suffix ? `${error.message}: ${suffix}` : error.message;
+  }
+
+  return error.message;
+}
+
+function validateHubHtml({ response, contentType, body }) {
+  return (
+    requireStatus(response) ||
+    (!hasHtmlContentType(contentType) ? `expected text/html content-type, got "${contentType || 'missing'}"` : null) ||
+    requireAnyBodyMatch(body, [/QR-V/i, /QRV\.network/i, /command hub/i, /Network Directory/i], 'QRV hub markers')
+  );
+}
+
+function validateHubStatus({ response, contentType, body }) {
+  return (
+    requireStatus(response) ||
+    (!hasHtmlContentType(contentType) ? `expected text/html content-type, got "${contentType || 'missing'}"` : null) ||
+    requireAnyBodyMatch(body, [/Production Status/i, /Status Links/i, /API Health/i, /Registry Authority/i], 'hub status markers')
+  );
+}
+
+function validateApiHealthJson({ response, contentType, body }) {
+  const baseError = requireStatus(response) || (!hasJsonContentType(contentType) ? `expected JSON content-type, got "${contentType || 'missing'}"` : null);
+  if (baseError) return baseError;
+
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed === 'object') {
+      return requireAnyBodyMatch(JSON.stringify(parsed), [/ok/i, /healthy/i, /health/i, /status/i, /version/i], 'health JSON markers');
+    }
+  } catch (error) {
+    return `expected valid JSON body (${error instanceof Error ? error.message : String(error)})`;
+  }
+
+  return 'expected JSON object body';
+}
+
+function validateRegistryStatus({ response, contentType, body }) {
+  const statusError = requireStatus(response);
+  if (statusError) return statusError;
+
+  if (hasJsonContentType(contentType)) {
+    try {
+      JSON.parse(body);
+    } catch (error) {
+      return `expected valid JSON registry/status body (${error instanceof Error ? error.message : String(error)})`;
+    }
+  }
+
+  return requireAnyBodyMatch(body, [/registry/i, /status/i, /ready/i, /health/i, /authority/i], 'registry/status markers');
+}
+
+function validateIssuerLogin({ response, contentType, body }) {
+  return (
+    requireStatus(response) ||
+    (!hasHtmlContentType(contentType) ? `expected text/html content-type, got "${contentType || 'missing'}"` : null) ||
+    requireAnyBodyMatch(body, [/issuer/i, /login/i, /sign in/i, /password/i], 'issuer login markers')
+  );
+}
+
+function validateStyledVerificationResult({ response, contentType, body }) {
+  return (
+    requireStatus(response) ||
+    (!hasHtmlContentType(contentType) ? `expected text/html content-type, got "${contentType || 'missing'}"` : null) ||
+    requireAnyBodyMatch(body, [/Verification Result/i, /QRV-DEMO-001/i, /VERIFIED|REVOKED|EXPIRED|NOT_FOUND/i], 'verification result markers') ||
+    requireAnyBodyMatch(body, [/style=/i, /class=/i, /stylesheet/i, /__next/i], 'styling markers')
+  );
+}
+
+async function fetchWithTimeout(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`timed out after ${DEFAULT_TIMEOUT_MS}ms`)), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        Accept: 'text/html,application/json;q=0.9,*/*;q=0.8',
+        'User-Agent': USER_AGENT,
+      },
+    });
+    const body = await response.text();
+    return { response, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runCheck(check) {
+  const startedAt = Date.now();
+
+  try {
+    const { response, body } = await fetchWithTimeout(check.url);
+    const contentType = response.headers.get('content-type') || '';
+    const error = check.validate({ response, contentType, body });
+
+    return {
+      ...check,
+      passed: !error,
+      status: response.status,
+      contentType,
+      finalUrl: response.url,
+      elapsedMs: Date.now() - startedAt,
+      error,
+    };
+  } catch (error) {
+    return {
+      ...check,
+      passed: false,
+      status: null,
+      contentType: '',
+      finalUrl: check.url,
+      elapsedMs: Date.now() - startedAt,
+      error: formatError(error),
+    };
+  }
+}
+
+function printResult(result) {
+  const state = result.passed ? 'PASS' : 'FAIL';
+  const status = result.status === null ? 'NO_RESPONSE' : result.status;
+  const details = `${state} ${result.domain} [${result.role}] ${status} ${result.elapsedMs}ms ${result.finalUrl}`;
+
+  if (result.passed) {
+    console.log(details);
+    return;
+  }
+
+  console.error(`${details} :: ${result.error} (expected ${result.expected}; requested ${result.url})`);
+}
+
+async function main() {
+  console.log(`QRV live domain audit started at ${new Date().toISOString()}`);
+  console.log(`Timeout per request: ${DEFAULT_TIMEOUT_MS}ms`);
+
+  const results = [];
+  for (const check of checks) {
+    const result = await runCheck(check);
+    results.push(result);
+    printResult(result);
+  }
+
+  const passed = results.filter((result) => result.passed).length;
+  const failed = results.length - passed;
+  console.log(`Summary: ${passed}/${results.length} checks passed; ${failed} failed.`);
+
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(formatError(error));
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Provide a single-source deployment contract for production hostnames and a simple automated audit to verify that each live domain resolves to the intended service surface.

### Description

- Add `docs/live-domain-map.md` documenting each live domain with the required repo/service, framework/runtime, entry file, required env vars, and smoke-test URLs.
- Add `scripts/audit-live-domains.mjs` that performs HTTP checks for `qrv.network` (root + `/status`), `api.qrv.network/healthz`, `registry.qrv.network` (root), `issuer.qrv.network/login`, and `verify.qrv.network/QRV-DEMO-001`, validating status codes, content-types, and expected body markers and reporting PASS/FAIL per domain.
- Add an npm script `audit:live` (`node scripts/audit-live-domains.mjs`) and update `package.json` scripts accordingly.
- Implement robust error formatting and a non-zero exit code when any check fails to allow CI/monitoring integration.

### Testing

- Ran `npm run check`, which succeeded (JS syntax check for `server.js`).
- Ran `npm run build`, which succeeded (build script is a no-op echo in this repo).
- Ran `node --check scripts/audit-live-domains.mjs`, which succeeded (script syntax validated).
- Ran `npm run audit:live`, which executed the audit and printed per-domain PASS/FAIL, but all checks failed in this environment with network errors (`ENETUNREACH`), and the script exited non-zero as designed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25a017eb70832d84741d7c453f848f)